### PR TITLE
chore: add CI and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # @escalated-dev/escalated-adonis
 
+[![Tests](https://github.com/escalated-dev/escalated-adonis/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated-adonis/actions/workflows/run-tests.yml)
+[![AdonisJS](https://img.shields.io/badge/adonisjs-v6-5A45FF?logo=adonisjs&logoColor=white)](https://adonisjs.com/)
+
 An embeddable support ticket system for AdonisJS v6 applications. Drop-in customer support with tickets, SLA management, departments, escalation rules, canned responses, macros, inbound email processing, satisfaction ratings, and a full admin panel -- all rendered via Inertia.js with Vue 3.
 
 ## Requirements


### PR DESCRIPTION
Adds build status and AdonisJS tech stack badges to README.