### PR TITLE
ci: add linting to CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    name: ESLint
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,14 @@
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  {
+    ignores: ['build/**', 'node_modules/**'],
+  },
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
+  }
+)

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "rm -rf build",
+    "lint": "eslint .",
     "test": "node --test tests/*.test.js",
     "prepublishOnly": "npm run build"
   },
@@ -62,7 +63,9 @@
     "@adonisjs/cache": "^1.0.0",
     "@adonisjs/mail": "^9.0.0",
     "@japa/runner": "^3.0.0",
-    "typescript": "^5.4.0"
+    "eslint": "^9.0.0",
+    "typescript": "^5.4.0",
+    "typescript-eslint": "^8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add ESLint 9 with typescript-eslint and flat config (`eslint.config.js`)
- Add `lint` script to package.json
- Create `lint.yml` workflow that runs ESLint on PRs to main

## Test plan
- [ ] Verify the lint workflow runs on PRs to main
- [ ] Verify ESLint catches TypeScript violations
- [ ] Verify existing test workflow is unaffected