### PR TITLE
feat: add ticket snooze/schedule

### DIFF
--- a/database/migrations/0025_add_snooze_fields_to_escalated_tickets.ts
+++ b/database/migrations/0025_add_snooze_fields_to_escalated_tickets.ts
@@ -1,0 +1,21 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class AddSnoozeFieldsToEscalatedTickets extends BaseSchema {
+  protected tableName = 'escalated_tickets'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.timestamp('snoozed_until', { useTz: true }).nullable()
+      table.integer('snoozed_by').unsigned().nullable()
+      table.string('status_before_snooze').nullable()
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('snoozed_until')
+      table.dropColumn('snoozed_by')
+      table.dropColumn('status_before_snooze')
+    })
+  }
+}

--- a/src/commands/wake_snoozed_tickets_command.ts
+++ b/src/commands/wake_snoozed_tickets_command.ts
@@ -1,0 +1,57 @@
+/*
+|--------------------------------------------------------------------------
+| escalated:wake-snoozed-tickets — CLI command
+|--------------------------------------------------------------------------
+|
+| Unsnooze all tickets whose snoozed_until has passed, restoring
+| their previous status.
+|
+|   node ace escalated:wake-snoozed-tickets
+|
+*/
+
+import { BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import Ticket from '../models/ticket.js'
+import TicketService from '../services/ticket_service.js'
+
+export default class WakeSnoozedTicketsCommand extends BaseCommand {
+  static commandName = 'escalated:wake-snoozed-tickets'
+
+  static description = 'Unsnooze tickets whose snooze period has elapsed'
+
+  static help = [
+    'Wake all snoozed tickets that are past their snoozed_until time:',
+    '  node ace escalated:wake-snoozed-tickets',
+  ]
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  async run() {
+    const ticketService = new TicketService()
+
+    this.logger.info('Checking for snoozed tickets to wake…')
+
+    try {
+      const tickets = await Ticket.query().withScopes((scopes) => scopes.awakeDue())
+
+      if (tickets.length === 0) {
+        this.logger.info('No snoozed tickets to wake.')
+        return
+      }
+
+      let woken = 0
+      for (const ticket of tickets) {
+        await ticketService.unsnoozeTicket(ticket)
+        woken++
+      }
+
+      this.logger.success(`Woke ${woken} snoozed ticket(s).`)
+    } catch (error: any) {
+      this.logger.error(`Failed to wake snoozed tickets: ${error.message}`)
+      this.exitCode = 1
+    }
+  }
+}

--- a/src/controllers/agent_tickets_controller.ts
+++ b/src/controllers/agent_tickets_controller.ts
@@ -300,6 +300,41 @@ export default class AgentTicketsController {
   }
 
   /**
+   * POST /support/agent/tickets/:ticket/snooze — Snooze a ticket
+   */
+  async snooze(ctx: HttpContext) {
+    const ticket = (ctx as any).escalatedTicket as Ticket
+    const user = ctx.auth.user!
+    const { snoozed_until: snoozedUntil } = ctx.request.only(['snoozed_until'])
+
+    const { DateTime } = await import('luxon')
+    const until = DateTime.fromISO(snoozedUntil)
+
+    if (!until.isValid) {
+      ctx.session.flash('error', t('ticket.invalid_snooze_date'))
+      return ctx.response.redirect().back()
+    }
+
+    await this.ticketService.snoozeTicket(ticket, until, user as any)
+
+    ctx.session.flash('success', t('ticket.snoozed'))
+    return ctx.response.redirect().back()
+  }
+
+  /**
+   * POST /support/agent/tickets/:ticket/unsnooze — Unsnooze a ticket
+   */
+  async unsnooze(ctx: HttpContext) {
+    const ticket = (ctx as any).escalatedTicket as Ticket
+    const user = ctx.auth.user!
+
+    await this.ticketService.unsnoozeTicket(ticket, user as any)
+
+    ctx.session.flash('success', t('ticket.unsnoozed'))
+    return ctx.response.redirect().back()
+  }
+
+  /**
    * POST /support/agent/tickets/:ticket/replies/:replyId/pin — Toggle pin
    */
   async pin(ctx: HttpContext) {

--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -112,6 +112,15 @@ export default class Ticket extends BaseModel {
   declare updatedAt: DateTime
 
   @column.dateTime()
+  declare snoozedUntil: DateTime | null
+
+  @column()
+  declare snoozedBy: number | null
+
+  @column()
+  declare statusBeforeSnooze: string | null
+
+  @column.dateTime()
   declare deletedAt: DateTime | null
 
   // ---- Relationships ----
@@ -145,6 +154,17 @@ export default class Ticket extends BaseModel {
   // We handle this through direct pivot table queries.
 
   // ---- Computed ----
+
+  @computed()
+  get isSnoozed(): boolean {
+    if (!this.snoozedUntil) return false
+    const now = new Date()
+    const snoozedUntil =
+      this.snoozedUntil instanceof Date
+        ? this.snoozedUntil
+        : new Date(this.snoozedUntil.toISO!() ?? this.snoozedUntil.toString())
+    return snoozedUntil > now
+  }
 
   @computed()
   get isGuest(): boolean {
@@ -191,6 +211,14 @@ export default class Ticket extends BaseModel {
 
   static inDepartment = scope((query, departmentId: number) => {
     query.where('department_id', departmentId)
+  })
+
+  static snoozed = scope((query) => {
+    query.whereNotNull('snoozed_until').where('snoozed_until', '>', new Date().toISOString())
+  })
+
+  static awakeDue = scope((query) => {
+    query.whereNotNull('snoozed_until').where('snoozed_until', '<=', new Date().toISOString())
   })
 
   static breachedSla = scope((query) => {

--- a/src/services/ticket_service.ts
+++ b/src/services/ticket_service.ts
@@ -396,6 +396,59 @@ export default class TicketService {
     return query.paginate(1, filters.per_page ?? 15)
   }
 
+  /**
+   * Snooze a ticket until a given date/time.
+   *
+   * Saves the current status so it can be restored when the ticket is unsnoozed.
+   */
+  async snoozeTicket(
+    ticket: Ticket,
+    until: DateTime,
+    causer: { id: number; constructor: { name: string } }
+  ): Promise<Ticket> {
+    ticket.statusBeforeSnooze = ticket.status
+    ticket.snoozedUntil = until
+    ticket.snoozedBy = causer.id
+    ticket.status = 'waiting_on_customer' as TicketStatus
+    await ticket.save()
+
+    await this.logActivity(ticket, 'status_changed', causer, {
+      action: 'snoozed',
+      snoozed_until: until.toISO(),
+      old_status: ticket.statusBeforeSnooze,
+    })
+
+    return ticket.refresh()
+  }
+
+  /**
+   * Unsnooze a ticket, restoring its previous status.
+   */
+  async unsnoozeTicket(ticket: Ticket, causer?: any): Promise<Ticket> {
+    const previousStatus = (ticket.statusBeforeSnooze || 'open') as TicketStatus
+    ticket.status = previousStatus
+    ticket.snoozedUntil = null
+    ticket.snoozedBy = null
+    ticket.statusBeforeSnooze = null
+    await ticket.save()
+
+    await this.logActivity(ticket, 'status_changed', causer, {
+      action: 'unsnoozed',
+      restored_status: previousStatus,
+    })
+
+    if (!ImportContext.isImporting()) {
+      await emitter.emit(ESCALATED_EVENTS.TICKET_STATUS_CHANGED, {
+        ticket,
+        oldStatus: 'waiting_on_customer' as TicketStatus,
+        newStatus: previousStatus,
+        causer,
+      })
+    }
+
+    return ticket.refresh()
+  }
+
   // ---- Private ----
 
   protected async logActivity(

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -186,6 +186,12 @@ function registerUiRoutes(config: any) {
           router
             .post('/tickets/:ticket/replies/:reply/pin', [AgentTicketsController, 'pin'])
             .as('escalated.agent.tickets.pin')
+          router
+            .post('/tickets/:ticket/snooze', [AgentTicketsController, 'snooze'])
+            .as('escalated.agent.tickets.snooze')
+          router
+            .post('/tickets/:ticket/unsnooze', [AgentTicketsController, 'unsnooze'])
+            .as('escalated.agent.tickets.unsnooze')
         })
         .use([ResolveTicket])
     })

--- a/tests/ticket_snooze.test.js
+++ b/tests/ticket_snooze.test.js
@@ -64,9 +64,7 @@ function isSnoozed(ticket) {
  */
 function filterAwakeDue(tickets) {
   const now = new Date()
-  return tickets.filter(
-    (t) => t.snoozedUntil !== null && new Date(t.snoozedUntil) <= now
-  )
+  return tickets.filter((t) => t.snoozedUntil !== null && new Date(t.snoozedUntil) <= now)
 }
 
 // ──────────────────────────────────────────────────────────────────

--- a/tests/ticket_snooze.test.js
+++ b/tests/ticket_snooze.test.js
@@ -1,0 +1,263 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+/*
+|--------------------------------------------------------------------------
+| Ticket Snooze Tests
+|--------------------------------------------------------------------------
+|
+| Unit tests for the ticket snooze/unsnooze feature.
+|
+*/
+
+// ──────────────────────────────────────────────────────────────────
+// Mock helpers
+// ──────────────────────────────────────────────────────────────────
+
+function buildMockTicket(overrides = {}) {
+  return {
+    id: 1,
+    status: 'open',
+    snoozedUntil: null,
+    snoozedBy: null,
+    statusBeforeSnooze: null,
+    ...overrides,
+  }
+}
+
+/**
+ * Simulate snoozeTicket logic
+ */
+function simulateSnooze(ticket, untilISO, causerId) {
+  const result = { ...ticket }
+  result.statusBeforeSnooze = result.status
+  result.snoozedUntil = untilISO
+  result.snoozedBy = causerId
+  result.status = 'waiting_on_customer'
+  return result
+}
+
+/**
+ * Simulate unsnoozeTicket logic
+ */
+function simulateUnsnooze(ticket) {
+  const result = { ...ticket }
+  const previousStatus = result.statusBeforeSnooze || 'open'
+  result.status = previousStatus
+  result.snoozedUntil = null
+  result.snoozedBy = null
+  result.statusBeforeSnooze = null
+  return result
+}
+
+/**
+ * Check if a ticket is currently snoozed (mirrors Ticket.isSnoozed computed)
+ */
+function isSnoozed(ticket) {
+  if (!ticket.snoozedUntil) return false
+  const snoozedUntil = new Date(ticket.snoozedUntil)
+  return snoozedUntil > new Date()
+}
+
+/**
+ * Filter tickets that are past their snooze time (mirrors Ticket.awakeDue scope)
+ */
+function filterAwakeDue(tickets) {
+  const now = new Date()
+  return tickets.filter(
+    (t) => t.snoozedUntil !== null && new Date(t.snoozedUntil) <= now
+  )
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────
+
+describe('Ticket Snooze', () => {
+  describe('snoozeTicket', () => {
+    it('saves the current status before snoozing', () => {
+      const ticket = buildMockTicket({ status: 'in_progress' })
+      const result = simulateSnooze(ticket, '2099-01-01T00:00:00.000Z', 5)
+
+      assert.equal(result.statusBeforeSnooze, 'in_progress')
+    })
+
+    it('sets status to waiting_on_customer when snoozed', () => {
+      const ticket = buildMockTicket({ status: 'open' })
+      const result = simulateSnooze(ticket, '2099-01-01T00:00:00.000Z', 5)
+
+      assert.equal(result.status, 'waiting_on_customer')
+    })
+
+    it('sets snoozedUntil to the specified date', () => {
+      const ticket = buildMockTicket()
+      const until = '2099-06-15T14:30:00.000Z'
+      const result = simulateSnooze(ticket, until, 5)
+
+      assert.equal(result.snoozedUntil, until)
+    })
+
+    it('records who snoozed the ticket', () => {
+      const ticket = buildMockTicket()
+      const result = simulateSnooze(ticket, '2099-01-01T00:00:00.000Z', 42)
+
+      assert.equal(result.snoozedBy, 42)
+    })
+
+    it('preserves other ticket fields', () => {
+      const ticket = buildMockTicket({ id: 99 })
+      const result = simulateSnooze(ticket, '2099-01-01T00:00:00.000Z', 5)
+
+      assert.equal(result.id, 99)
+    })
+  })
+
+  describe('unsnoozeTicket', () => {
+    it('restores the previous status', () => {
+      const snoozed = buildMockTicket({
+        status: 'waiting_on_customer',
+        statusBeforeSnooze: 'in_progress',
+        snoozedUntil: '2099-01-01T00:00:00.000Z',
+        snoozedBy: 5,
+      })
+      const result = simulateUnsnooze(snoozed)
+
+      assert.equal(result.status, 'in_progress')
+    })
+
+    it('defaults to open if no previous status was saved', () => {
+      const snoozed = buildMockTicket({
+        status: 'waiting_on_customer',
+        statusBeforeSnooze: null,
+        snoozedUntil: '2099-01-01T00:00:00.000Z',
+        snoozedBy: 5,
+      })
+      const result = simulateUnsnooze(snoozed)
+
+      assert.equal(result.status, 'open')
+    })
+
+    it('clears snoozedUntil', () => {
+      const snoozed = buildMockTicket({
+        status: 'waiting_on_customer',
+        statusBeforeSnooze: 'open',
+        snoozedUntil: '2099-01-01T00:00:00.000Z',
+        snoozedBy: 5,
+      })
+      const result = simulateUnsnooze(snoozed)
+
+      assert.equal(result.snoozedUntil, null)
+    })
+
+    it('clears snoozedBy', () => {
+      const snoozed = buildMockTicket({
+        status: 'waiting_on_customer',
+        statusBeforeSnooze: 'open',
+        snoozedUntil: '2099-01-01T00:00:00.000Z',
+        snoozedBy: 5,
+      })
+      const result = simulateUnsnooze(snoozed)
+
+      assert.equal(result.snoozedBy, null)
+    })
+
+    it('clears statusBeforeSnooze', () => {
+      const snoozed = buildMockTicket({
+        status: 'waiting_on_customer',
+        statusBeforeSnooze: 'open',
+        snoozedUntil: '2099-01-01T00:00:00.000Z',
+        snoozedBy: 5,
+      })
+      const result = simulateUnsnooze(snoozed)
+
+      assert.equal(result.statusBeforeSnooze, null)
+    })
+  })
+
+  describe('isSnoozed computed property', () => {
+    it('returns false when snoozedUntil is null', () => {
+      const ticket = buildMockTicket({ snoozedUntil: null })
+      assert.equal(isSnoozed(ticket), false)
+    })
+
+    it('returns true when snoozedUntil is in the future', () => {
+      const ticket = buildMockTicket({ snoozedUntil: '2099-12-31T23:59:59.000Z' })
+      assert.equal(isSnoozed(ticket), true)
+    })
+
+    it('returns false when snoozedUntil is in the past', () => {
+      const ticket = buildMockTicket({ snoozedUntil: '2000-01-01T00:00:00.000Z' })
+      assert.equal(isSnoozed(ticket), false)
+    })
+  })
+
+  describe('awakeDue scope', () => {
+    it('returns tickets whose snooze time has passed', () => {
+      const tickets = [
+        buildMockTicket({ id: 1, snoozedUntil: '2000-01-01T00:00:00.000Z' }),
+        buildMockTicket({ id: 2, snoozedUntil: '2099-12-31T23:59:59.000Z' }),
+        buildMockTicket({ id: 3, snoozedUntil: null }),
+      ]
+      const due = filterAwakeDue(tickets)
+
+      assert.equal(due.length, 1)
+      assert.equal(due[0].id, 1)
+    })
+
+    it('returns empty array when no tickets are due', () => {
+      const tickets = [
+        buildMockTicket({ id: 1, snoozedUntil: '2099-12-31T23:59:59.000Z' }),
+        buildMockTicket({ id: 2, snoozedUntil: null }),
+      ]
+      const due = filterAwakeDue(tickets)
+
+      assert.equal(due.length, 0)
+    })
+
+    it('returns multiple tickets when several are past due', () => {
+      const tickets = [
+        buildMockTicket({ id: 1, snoozedUntil: '2000-01-01T00:00:00.000Z' }),
+        buildMockTicket({ id: 2, snoozedUntil: '2020-06-15T12:00:00.000Z' }),
+        buildMockTicket({ id: 3, snoozedUntil: '2099-12-31T23:59:59.000Z' }),
+      ]
+      const due = filterAwakeDue(tickets)
+
+      assert.equal(due.length, 2)
+    })
+  })
+
+  describe('snooze round-trip', () => {
+    it('restores original status after snooze and unsnooze cycle', () => {
+      const original = buildMockTicket({ status: 'escalated' })
+      const snoozed = simulateSnooze(original, '2099-01-01T00:00:00.000Z', 5)
+      const unsnoozed = simulateUnsnooze(snoozed)
+
+      assert.equal(unsnoozed.status, 'escalated')
+      assert.equal(unsnoozed.snoozedUntil, null)
+      assert.equal(unsnoozed.snoozedBy, null)
+      assert.equal(unsnoozed.statusBeforeSnooze, null)
+    })
+
+    it('handles multiple snooze cycles correctly', () => {
+      let ticket = buildMockTicket({ status: 'in_progress' })
+
+      // First snooze
+      ticket = simulateSnooze(ticket, '2099-01-01T00:00:00.000Z', 1)
+      assert.equal(ticket.status, 'waiting_on_customer')
+      assert.equal(ticket.statusBeforeSnooze, 'in_progress')
+
+      // First unsnooze
+      ticket = simulateUnsnooze(ticket)
+      assert.equal(ticket.status, 'in_progress')
+
+      // Second snooze
+      ticket = simulateSnooze(ticket, '2099-06-01T00:00:00.000Z', 2)
+      assert.equal(ticket.status, 'waiting_on_customer')
+      assert.equal(ticket.statusBeforeSnooze, 'in_progress')
+
+      // Second unsnooze
+      ticket = simulateUnsnooze(ticket)
+      assert.equal(ticket.status, 'in_progress')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add migration for `snoozed_until`, `snoozed_by`, `status_before_snooze` columns on tickets table
- Add `isSnoozed` computed property, `snoozed` and `awakeDue` scopes to Ticket model
- Add `snoozeTicket` and `unsnoozeTicket` methods to TicketService
- Add `escalated:wake-snoozed-tickets` Ace command to auto-wake expired snoozed tickets
- Add controller actions and routes: `POST /tickets/:id/snooze`, `POST /tickets/:id/unsnooze`

## Test plan
- [x] Unit tests for snooze (saves previous status, sets waiting_on_customer, records who/when)
- [x] Unit tests for unsnooze (restores previous status, clears snooze fields, defaults to open)
- [x] Unit tests for isSnoozed computed (null, future, past dates)
- [x] Unit tests for awakeDue scope filtering
- [x] Unit tests for round-trip snooze/unsnooze cycles