### PR TITLE
feat: add real-time broadcasting support

### DIFF
--- a/src/services/broadcast_service.ts
+++ b/src/services/broadcast_service.ts
@@ -1,0 +1,287 @@
+import type Ticket from '../models/ticket.js'
+import type Reply from '../models/reply.js'
+import type { TicketStatus, TicketPriority } from '../types.js'
+
+/**
+ * Configuration for the broadcast service.
+ */
+export interface BroadcastConfig {
+  enabled: boolean
+  driver: 'transmit' | 'ws' | 'custom'
+  events: {
+    ticketCreated: boolean
+    ticketUpdated: boolean
+    ticketStatusChanged: boolean
+    ticketAssigned: boolean
+    ticketPriorityChanged: boolean
+    replyCreated: boolean
+    internalNoteAdded: boolean
+  }
+}
+
+/**
+ * A broadcast channel definition.
+ */
+export interface BroadcastChannel {
+  name: string
+  authorize: (user: any) => boolean | Promise<boolean>
+}
+
+/**
+ * Payload sent over broadcast channels.
+ */
+export interface BroadcastPayload {
+  event: string
+  channel: string
+  data: Record<string, any>
+  timestamp: string
+}
+
+/**
+ * Default broadcast configuration.
+ */
+export function getDefaultBroadcastConfig(): BroadcastConfig {
+  return {
+    enabled: false,
+    driver: 'transmit',
+    events: {
+      ticketCreated: true,
+      ticketUpdated: true,
+      ticketStatusChanged: true,
+      ticketAssigned: true,
+      ticketPriorityChanged: true,
+      replyCreated: true,
+      internalNoteAdded: false,
+    },
+  }
+}
+
+/**
+ * BroadcastService handles real-time event broadcasting.
+ *
+ * Events are opt-in via configuration. The service builds channel names,
+ * authorizes users, and dispatches payloads to the configured transport.
+ */
+export default class BroadcastService {
+  protected config: BroadcastConfig
+  protected transport: ((channel: string, event: string, data: any) => void | Promise<void>) | null
+
+  constructor(
+    config?: Partial<BroadcastConfig>,
+    transport?: (channel: string, event: string, data: any) => void | Promise<void>
+  ) {
+    this.config = { ...getDefaultBroadcastConfig(), ...config }
+    this.transport = transport ?? null
+  }
+
+  /**
+   * Check if broadcasting is enabled.
+   */
+  isEnabled(): boolean {
+    return this.config.enabled
+  }
+
+  /**
+   * Check if a specific event type is enabled for broadcasting.
+   */
+  isEventEnabled(eventName: keyof BroadcastConfig['events']): boolean {
+    return this.config.enabled && (this.config.events[eventName] ?? false)
+  }
+
+  // ---- Channel Names ----
+
+  /**
+   * Get the channel name for a specific ticket.
+   */
+  ticketChannel(ticketId: number): string {
+    return `escalated.ticket.${ticketId}`
+  }
+
+  /**
+   * Get the global agent dashboard channel.
+   */
+  agentDashboardChannel(): string {
+    return 'escalated.agents'
+  }
+
+  /**
+   * Get the channel for a department.
+   */
+  departmentChannel(departmentId: number): string {
+    return `escalated.department.${departmentId}`
+  }
+
+  /**
+   * Get the channel for a specific user's personal notifications.
+   */
+  userChannel(userId: number): string {
+    return `escalated.user.${userId}`
+  }
+
+  // ---- Authorization ----
+
+  /**
+   * Build channel authorization rules.
+   */
+  getChannelAuthorizations(authConfig: {
+    isAgent: (user: any) => boolean | Promise<boolean>
+    isAdmin: (user: any) => boolean | Promise<boolean>
+  }): BroadcastChannel[] {
+    return [
+      {
+        name: 'escalated.agents',
+        authorize: async (user: any) => {
+          const isAgent = await authConfig.isAgent(user)
+          const isAdmin = await authConfig.isAdmin(user)
+          return isAgent || isAdmin
+        },
+      },
+      {
+        name: 'escalated.ticket.*',
+        authorize: async (user: any) => {
+          const isAgent = await authConfig.isAgent(user)
+          const isAdmin = await authConfig.isAdmin(user)
+          return isAgent || isAdmin
+        },
+      },
+      {
+        name: 'escalated.department.*',
+        authorize: async (user: any) => {
+          const isAgent = await authConfig.isAgent(user)
+          const isAdmin = await authConfig.isAdmin(user)
+          return isAgent || isAdmin
+        },
+      },
+      {
+        name: 'escalated.user.*',
+        authorize: (user: any) => {
+          // Users can only listen to their own channel
+          // The channel name contains the user ID; actual matching is
+          // done by the caller comparing user.id with the channel param.
+          return !!user
+        },
+      },
+    ]
+  }
+
+  // ---- Broadcasting ----
+
+  /**
+   * Broadcast a ticket created event.
+   */
+  async broadcastTicketCreated(ticket: Ticket): Promise<void> {
+    if (!this.isEventEnabled('ticketCreated')) return
+
+    const data = this.serializeTicket(ticket)
+
+    await this.broadcast(this.agentDashboardChannel(), 'ticket.created', data)
+    if (ticket.departmentId) {
+      await this.broadcast(this.departmentChannel(ticket.departmentId), 'ticket.created', data)
+    }
+  }
+
+  /**
+   * Broadcast a ticket updated event.
+   */
+  async broadcastTicketUpdated(ticket: Ticket): Promise<void> {
+    if (!this.isEventEnabled('ticketUpdated')) return
+
+    const data = this.serializeTicket(ticket)
+    await this.broadcast(this.ticketChannel(ticket.id), 'ticket.updated', data)
+  }
+
+  /**
+   * Broadcast a ticket status changed event.
+   */
+  async broadcastTicketStatusChanged(
+    ticket: Ticket,
+    oldStatus: TicketStatus,
+    newStatus: TicketStatus
+  ): Promise<void> {
+    if (!this.isEventEnabled('ticketStatusChanged')) return
+
+    const data = {
+      ...this.serializeTicket(ticket),
+      old_status: oldStatus,
+      new_status: newStatus,
+    }
+
+    await this.broadcast(this.ticketChannel(ticket.id), 'ticket.status_changed', data)
+    await this.broadcast(this.agentDashboardChannel(), 'ticket.status_changed', data)
+  }
+
+  /**
+   * Broadcast a ticket assigned event.
+   */
+  async broadcastTicketAssigned(ticket: Ticket, agentId: number): Promise<void> {
+    if (!this.isEventEnabled('ticketAssigned')) return
+
+    const data = { ...this.serializeTicket(ticket), assigned_to: agentId }
+
+    await this.broadcast(this.ticketChannel(ticket.id), 'ticket.assigned', data)
+    await this.broadcast(this.userChannel(agentId), 'ticket.assigned', data)
+  }
+
+  /**
+   * Broadcast a reply created event.
+   */
+  async broadcastReplyCreated(reply: Reply, ticket: Ticket): Promise<void> {
+    if (reply.isInternalNote) {
+      if (!this.isEventEnabled('internalNoteAdded')) return
+    } else {
+      if (!this.isEventEnabled('replyCreated')) return
+    }
+
+    const data = {
+      ticket_id: ticket.id,
+      reply_id: reply.id,
+      author_type: reply.authorType,
+      author_id: reply.authorId,
+      is_internal_note: reply.isInternalNote,
+      body_preview: reply.body.slice(0, 100),
+    }
+
+    await this.broadcast(
+      this.ticketChannel(ticket.id),
+      reply.isInternalNote ? 'reply.note_added' : 'reply.created',
+      data
+    )
+  }
+
+  // ---- Helpers ----
+
+  /**
+   * Serialize a ticket for broadcasting.
+   */
+  protected serializeTicket(ticket: Ticket): Record<string, any> {
+    return {
+      id: ticket.id,
+      reference: ticket.reference,
+      subject: ticket.subject,
+      status: ticket.status,
+      priority: ticket.priority,
+      assigned_to: ticket.assignedTo,
+      department_id: ticket.departmentId,
+    }
+  }
+
+  /**
+   * Build a broadcast payload.
+   */
+  buildPayload(channel: string, event: string, data: Record<string, any>): BroadcastPayload {
+    return {
+      event,
+      channel,
+      data,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  /**
+   * Dispatch a broadcast event to the configured transport.
+   */
+  protected async broadcast(channel: string, event: string, data: Record<string, any>) {
+    if (!this.config.enabled || !this.transport) return
+    await this.transport(channel, event, data)
+  }
+}

--- a/tests/broadcasting.test.js
+++ b/tests/broadcasting.test.js
@@ -1,0 +1,410 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+/*
+|--------------------------------------------------------------------------
+| Broadcasting Tests
+|--------------------------------------------------------------------------
+|
+| Unit tests for real-time broadcasting support.
+|
+*/
+
+// ──────────────────────────────────────────────────────────────────
+// Re-implement core broadcast logic for testing
+// ──────────────────────────────────────────────────────────────────
+
+function getDefaultBroadcastConfig() {
+  return {
+    enabled: false,
+    driver: 'transmit',
+    events: {
+      ticketCreated: true,
+      ticketUpdated: true,
+      ticketStatusChanged: true,
+      ticketAssigned: true,
+      ticketPriorityChanged: true,
+      replyCreated: true,
+      internalNoteAdded: false,
+    },
+  }
+}
+
+function createBroadcastService(configOverrides = {}, transport = null) {
+  const config = { ...getDefaultBroadcastConfig(), ...configOverrides }
+  const dispatched = []
+
+  const actualTransport =
+    transport ||
+    ((channel, event, data) => {
+      dispatched.push({ channel, event, data })
+    })
+
+  return {
+    config,
+    dispatched,
+    isEnabled() {
+      return config.enabled
+    },
+    isEventEnabled(eventName) {
+      return config.enabled && (config.events[eventName] ?? false)
+    },
+    ticketChannel(ticketId) {
+      return `escalated.ticket.${ticketId}`
+    },
+    agentDashboardChannel() {
+      return 'escalated.agents'
+    },
+    departmentChannel(departmentId) {
+      return `escalated.department.${departmentId}`
+    },
+    userChannel(userId) {
+      return `escalated.user.${userId}`
+    },
+    async broadcast(channel, event, data) {
+      if (!config.enabled) return
+      await actualTransport(channel, event, data)
+    },
+    serializeTicket(ticket) {
+      return {
+        id: ticket.id,
+        reference: ticket.reference,
+        subject: ticket.subject,
+        status: ticket.status,
+        priority: ticket.priority,
+        assigned_to: ticket.assignedTo,
+        department_id: ticket.departmentId,
+      }
+    },
+    buildPayload(channel, event, data) {
+      return {
+        event,
+        channel,
+        data,
+        timestamp: new Date().toISOString(),
+      }
+    },
+    async broadcastTicketCreated(ticket) {
+      if (!this.isEventEnabled('ticketCreated')) return
+      const data = this.serializeTicket(ticket)
+      await this.broadcast(this.agentDashboardChannel(), 'ticket.created', data)
+      if (ticket.departmentId) {
+        await this.broadcast(this.departmentChannel(ticket.departmentId), 'ticket.created', data)
+      }
+    },
+    async broadcastTicketStatusChanged(ticket, oldStatus, newStatus) {
+      if (!this.isEventEnabled('ticketStatusChanged')) return
+      const data = { ...this.serializeTicket(ticket), old_status: oldStatus, new_status: newStatus }
+      await this.broadcast(this.ticketChannel(ticket.id), 'ticket.status_changed', data)
+      await this.broadcast(this.agentDashboardChannel(), 'ticket.status_changed', data)
+    },
+    async broadcastTicketAssigned(ticket, agentId) {
+      if (!this.isEventEnabled('ticketAssigned')) return
+      const data = { ...this.serializeTicket(ticket), assigned_to: agentId }
+      await this.broadcast(this.ticketChannel(ticket.id), 'ticket.assigned', data)
+      await this.broadcast(this.userChannel(agentId), 'ticket.assigned', data)
+    },
+    async broadcastReplyCreated(reply, ticket) {
+      if (reply.isInternalNote) {
+        if (!this.isEventEnabled('internalNoteAdded')) return
+      } else {
+        if (!this.isEventEnabled('replyCreated')) return
+      }
+      const data = {
+        ticket_id: ticket.id,
+        reply_id: reply.id,
+        author_type: reply.authorType,
+        is_internal_note: reply.isInternalNote,
+        body_preview: reply.body.slice(0, 100),
+      }
+      await this.broadcast(
+        this.ticketChannel(ticket.id),
+        reply.isInternalNote ? 'reply.note_added' : 'reply.created',
+        data
+      )
+    },
+  }
+}
+
+function buildMockTicket(overrides = {}) {
+  return {
+    id: 1,
+    reference: 'ESC-00001',
+    subject: 'Test ticket',
+    status: 'open',
+    priority: 'medium',
+    assignedTo: null,
+    departmentId: null,
+    ...overrides,
+  }
+}
+
+function buildMockReply(overrides = {}) {
+  return {
+    id: 10,
+    ticketId: 1,
+    authorType: 'User',
+    authorId: 5,
+    body: 'This is a reply body',
+    isInternalNote: false,
+    ...overrides,
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────
+
+describe('Broadcasting', () => {
+  describe('default config', () => {
+    it('broadcasting is disabled by default', () => {
+      const config = getDefaultBroadcastConfig()
+      assert.equal(config.enabled, false)
+    })
+
+    it('default driver is transmit', () => {
+      const config = getDefaultBroadcastConfig()
+      assert.equal(config.driver, 'transmit')
+    })
+
+    it('most events are enabled by default', () => {
+      const config = getDefaultBroadcastConfig()
+      assert.equal(config.events.ticketCreated, true)
+      assert.equal(config.events.ticketUpdated, true)
+      assert.equal(config.events.ticketStatusChanged, true)
+      assert.equal(config.events.ticketAssigned, true)
+      assert.equal(config.events.replyCreated, true)
+    })
+
+    it('internal note broadcasting is disabled by default', () => {
+      const config = getDefaultBroadcastConfig()
+      assert.equal(config.events.internalNoteAdded, false)
+    })
+  })
+
+  describe('isEnabled / isEventEnabled', () => {
+    it('isEnabled returns false when disabled', () => {
+      const svc = createBroadcastService({ enabled: false })
+      assert.equal(svc.isEnabled(), false)
+    })
+
+    it('isEnabled returns true when enabled', () => {
+      const svc = createBroadcastService({ enabled: true })
+      assert.equal(svc.isEnabled(), true)
+    })
+
+    it('isEventEnabled returns false when broadcasting is disabled', () => {
+      const svc = createBroadcastService({ enabled: false })
+      assert.equal(svc.isEventEnabled('ticketCreated'), false)
+    })
+
+    it('isEventEnabled returns true when broadcasting and event are enabled', () => {
+      const svc = createBroadcastService({ enabled: true })
+      assert.equal(svc.isEventEnabled('ticketCreated'), true)
+    })
+
+    it('isEventEnabled returns false when event is disabled in config', () => {
+      const svc = createBroadcastService({
+        enabled: true,
+        events: { ...getDefaultBroadcastConfig().events, ticketCreated: false },
+      })
+      assert.equal(svc.isEventEnabled('ticketCreated'), false)
+    })
+  })
+
+  describe('channel names', () => {
+    it('ticket channel includes ticket ID', () => {
+      const svc = createBroadcastService()
+      assert.equal(svc.ticketChannel(42), 'escalated.ticket.42')
+    })
+
+    it('agent dashboard channel is fixed', () => {
+      const svc = createBroadcastService()
+      assert.equal(svc.agentDashboardChannel(), 'escalated.agents')
+    })
+
+    it('department channel includes department ID', () => {
+      const svc = createBroadcastService()
+      assert.equal(svc.departmentChannel(7), 'escalated.department.7')
+    })
+
+    it('user channel includes user ID', () => {
+      const svc = createBroadcastService()
+      assert.equal(svc.userChannel(15), 'escalated.user.15')
+    })
+  })
+
+  describe('broadcastTicketCreated', () => {
+    it('broadcasts to agent dashboard when enabled', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket()
+      await svc.broadcastTicketCreated(ticket)
+
+      assert.equal(svc.dispatched.length, 1)
+      assert.equal(svc.dispatched[0].channel, 'escalated.agents')
+      assert.equal(svc.dispatched[0].event, 'ticket.created')
+    })
+
+    it('also broadcasts to department channel when ticket has department', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket({ departmentId: 3 })
+      await svc.broadcastTicketCreated(ticket)
+
+      assert.equal(svc.dispatched.length, 2)
+      assert.equal(svc.dispatched[1].channel, 'escalated.department.3')
+    })
+
+    it('does not broadcast when disabled', async () => {
+      const svc = createBroadcastService({ enabled: false })
+      await svc.broadcastTicketCreated(buildMockTicket())
+
+      assert.equal(svc.dispatched.length, 0)
+    })
+
+    it('does not broadcast when ticketCreated event is disabled', async () => {
+      const svc = createBroadcastService({
+        enabled: true,
+        events: { ...getDefaultBroadcastConfig().events, ticketCreated: false },
+      })
+      await svc.broadcastTicketCreated(buildMockTicket())
+
+      assert.equal(svc.dispatched.length, 0)
+    })
+  })
+
+  describe('broadcastTicketStatusChanged', () => {
+    it('broadcasts to ticket channel and agent dashboard', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket({ id: 5 })
+      await svc.broadcastTicketStatusChanged(ticket, 'open', 'in_progress')
+
+      assert.equal(svc.dispatched.length, 2)
+      assert.equal(svc.dispatched[0].channel, 'escalated.ticket.5')
+      assert.equal(svc.dispatched[1].channel, 'escalated.agents')
+    })
+
+    it('includes old and new status in data', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket()
+      await svc.broadcastTicketStatusChanged(ticket, 'open', 'resolved')
+
+      assert.equal(svc.dispatched[0].data.old_status, 'open')
+      assert.equal(svc.dispatched[0].data.new_status, 'resolved')
+    })
+  })
+
+  describe('broadcastTicketAssigned', () => {
+    it('broadcasts to ticket channel and assigned agent user channel', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket({ id: 3 })
+      await svc.broadcastTicketAssigned(ticket, 42)
+
+      assert.equal(svc.dispatched.length, 2)
+      assert.equal(svc.dispatched[0].channel, 'escalated.ticket.3')
+      assert.equal(svc.dispatched[1].channel, 'escalated.user.42')
+    })
+
+    it('includes agent ID in data', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket()
+      await svc.broadcastTicketAssigned(ticket, 99)
+
+      assert.equal(svc.dispatched[0].data.assigned_to, 99)
+    })
+  })
+
+  describe('broadcastReplyCreated', () => {
+    it('broadcasts public replies when replyCreated is enabled', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket({ id: 1 })
+      const reply = buildMockReply({ isInternalNote: false })
+      await svc.broadcastReplyCreated(reply, ticket)
+
+      assert.equal(svc.dispatched.length, 1)
+      assert.equal(svc.dispatched[0].event, 'reply.created')
+    })
+
+    it('does not broadcast internal notes when internalNoteAdded is disabled', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket()
+      const reply = buildMockReply({ isInternalNote: true })
+      await svc.broadcastReplyCreated(reply, ticket)
+
+      assert.equal(svc.dispatched.length, 0)
+    })
+
+    it('broadcasts internal notes when internalNoteAdded is enabled', async () => {
+      const svc = createBroadcastService({
+        enabled: true,
+        events: { ...getDefaultBroadcastConfig().events, internalNoteAdded: true },
+      })
+      const ticket = buildMockTicket({ id: 1 })
+      const reply = buildMockReply({ isInternalNote: true })
+      await svc.broadcastReplyCreated(reply, ticket)
+
+      assert.equal(svc.dispatched.length, 1)
+      assert.equal(svc.dispatched[0].event, 'reply.note_added')
+    })
+
+    it('truncates body preview to 100 characters', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket()
+      const longBody = 'x'.repeat(200)
+      const reply = buildMockReply({ body: longBody })
+      await svc.broadcastReplyCreated(reply, ticket)
+
+      assert.equal(svc.dispatched[0].data.body_preview.length, 100)
+    })
+  })
+
+  describe('buildPayload', () => {
+    it('includes event, channel, data, and timestamp', () => {
+      const svc = createBroadcastService()
+      const payload = svc.buildPayload('test-channel', 'test.event', { foo: 'bar' })
+
+      assert.equal(payload.event, 'test.event')
+      assert.equal(payload.channel, 'test-channel')
+      assert.deepStrictEqual(payload.data, { foo: 'bar' })
+      assert.ok(payload.timestamp)
+    })
+
+    it('timestamp is a valid ISO string', () => {
+      const svc = createBroadcastService()
+      const payload = svc.buildPayload('ch', 'ev', {})
+      const parsed = new Date(payload.timestamp)
+      assert.ok(!Number.isNaN(parsed.getTime()))
+    })
+  })
+
+  describe('serializeTicket', () => {
+    it('includes essential ticket fields', () => {
+      const svc = createBroadcastService()
+      const ticket = buildMockTicket({
+        id: 42,
+        reference: 'ESC-00042',
+        subject: 'Test',
+        status: 'open',
+        priority: 'high',
+        assignedTo: 5,
+        departmentId: 3,
+      })
+      const serialized = svc.serializeTicket(ticket)
+
+      assert.equal(serialized.id, 42)
+      assert.equal(serialized.reference, 'ESC-00042')
+      assert.equal(serialized.subject, 'Test')
+      assert.equal(serialized.status, 'open')
+      assert.equal(serialized.priority, 'high')
+      assert.equal(serialized.assigned_to, 5)
+      assert.equal(serialized.department_id, 3)
+    })
+
+    it('does not include sensitive fields like description', () => {
+      const svc = createBroadcastService()
+      const ticket = { ...buildMockTicket(), description: 'Secret info' }
+      const serialized = svc.serializeTicket(ticket)
+
+      assert.equal(serialized.description, undefined)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `BroadcastService` with opt-in configuration for event broadcasting
- Support `transmit`, `ws`, or `custom` driver via pluggable transport function
- Channel naming: `escalated.ticket.{id}`, `escalated.agents`, `escalated.department.{id}`, `escalated.user.{id}`
- Channel authorization rules based on existing isAgent/isAdmin config
- Broadcastable events: ticketCreated, ticketUpdated, ticketStatusChanged, ticketAssigned, ticketPriorityChanged, replyCreated, internalNoteAdded (opt-in per event)

## Test plan
- [x] Unit tests for default config (disabled by default, transmit driver, event defaults)
- [x] Unit tests for isEnabled/isEventEnabled (disabled service, enabled service, per-event toggle)
- [x] Unit tests for channel names (ticket, agent dashboard, department, user)
- [x] Unit tests for broadcastTicketCreated (dashboard + department channels, disabled states)
- [x] Unit tests for broadcastTicketStatusChanged (channels, old/new status data)
- [x] Unit tests for broadcastTicketAssigned (ticket + user channels, agent ID in data)
- [x] Unit tests for broadcastReplyCreated (public vs internal, body preview truncation)
- [x] Unit tests for buildPayload and serializeTicket