### PR TITLE
docs: add translated READMEs (13 languages)

### DIFF
--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <b>العربية</b> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## المتطلبات
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## التثبيت
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## الإعدادات
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## الميزات
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## الأحداث
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## البريد الوارد
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -451,7 +451,7 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## حزمة SDK للإضافات
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## متوفر أيضاً لـ
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## الرخصة
 
 MIT

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <b>Deutsch</b> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Voraussetzungen
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## Konfiguration
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Funktionen
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## Ereignisse
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## Eingehende E-Mails
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Auch verfügbar für
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Lizenz
 
 MIT

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <b>Español</b> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Requisitos
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## Instalación
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## Configuración
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Características
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## Eventos
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## Correo Entrante
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## También Disponible Para
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licencia
 
 MIT

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <b>Français</b> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Prérequis
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Fonctionnalités
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## Événements
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## E-mail Entrant
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Également Disponible Pour
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licence
 
 MIT

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <b>Italiano</b> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Requisiti
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## Installazione
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## Configurazione
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Funzionalità
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## Eventi
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## Email in Entrata
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Disponibile Anche Per
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licenza
 
 MIT

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <b>日本語</b> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## 要件
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## インストール
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## 設定
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## 機能
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## イベント
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## 受信メール
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -451,7 +451,7 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## プラグインSDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## 他のフレームワーク向け
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## ライセンス
 
 MIT

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <b>한국어</b> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## 요구 사항
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## 설치
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## 설정
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## 기능
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## 이벤트
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## 수신 이메일
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -451,7 +451,7 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## 플러그인 SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## 다른 프레임워크에서도 사용 가능
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## 라이선스
 
 MIT

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <b>Nederlands</b> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Vereisten
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## Installatie
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## Configuratie
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Functies
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## Gebeurtenissen
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## Inkomende E-mail
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Ook Beschikbaar Voor
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licentie
 
 MIT

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <b>Polski</b> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Wymagania
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## Instalacja
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## Konfiguracja
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Funkcje
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## Zdarzenia
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## Poczta Przychodząca
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Dostępne Również Dla
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licencja
 
 MIT

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <b>Português (BR)</b> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Requisitos
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## Instalação
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## Configuração
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Recursos
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## Eventos
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## E-mail de Entrada
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Também Disponível Para
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licença
 
 MIT

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <b>Русский</b> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Требования
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## Установка
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## Конфигурация
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Возможности
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## События
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## Входящая почта
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Также доступно для
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Лицензия
 
 MIT

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <b>Türkçe</b> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## Gereksinimler
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## Kurulum
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## Yapılandırma
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## Özellikler
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## Olaylar
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## Gelen E-posta
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Şunlar İçin de Mevcut
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Lisans
 
 MIT

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <b>简体中文</b>
 </p>
 
 # Escalated for AdonisJS
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## Requirements
+## 系统要求
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -35,7 +35,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 - @adonisjs/mail ^9.0 (optional, for notifications)
 - Node.js 20+
 
-## Installation
+## 安装
 
 ```bash
 npm install @escalated-dev/escalated-adonis
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## Configuration
+## 配置
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Features
+## 功能特性
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -383,7 +383,7 @@ The provider automatically shares the following data via Inertia on every reques
 }
 ```
 
-## Events
+## 事件
 
 The package emits the following events that you can listen to:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Inbound Email
+## 入站邮件
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -451,7 +451,7 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## 插件 SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -503,7 +503,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## 其他框架版本
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -514,6 +514,6 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## 许可证
 
 MIT


### PR DESCRIPTION
## Summary
- Add translated README files in `docs/translations/` for 13 languages: Arabic, German, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portuguese, Russian, Turkish, and Chinese Simplified
- Add language selector bar at the top of the main README.md
- Each translated README includes the same language selector with the current language bolded and translated section headings

## Test plan
- [ ] Verify language selector links work in the main README
- [ ] Verify each translated file has correct language selector
- [ ] Verify English links back to ../../README.md from translation files