### PR TITLE
feat: add 10 additional locales

### DIFF
--- a/resources/lang/ar/messages.json
+++ b/resources/lang/ar/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "تم إرسال الرد.",
+    "note_added": "تمت إضافة الملاحظة.",
+    "assigned": "تم تعيين التذكرة.",
+    "status_updated": "تم تحديث الحالة.",
+    "priority_updated": "تم تحديث الأولوية.",
+    "tags_updated": "تم تحديث الوسوم.",
+    "department_updated": "تم تحديث القسم.",
+    "macro_applied": "تم تطبيق الماكرو \":name\".",
+    "unfollowed": "تم إلغاء متابعة التذكرة.",
+    "following": "أنت تتابع التذكرة.",
+    "note_pinned": "تم تثبيت الملاحظة.",
+    "note_unpinned": "تم إلغاء تثبيت الملاحظة.",
+    "pin_notes_only": "يمكن تثبيت الملاحظات الداخلية فقط.",
+    "updated": "تم تحديث التذكرة.",
+    "created": "تم إنشاء التذكرة بنجاح.",
+    "closed": "تم إغلاق التذكرة.",
+    "reopened": "تم إعادة فتح التذكرة.",
+    "customer_close_forbidden": "لا يمكن للعملاء إغلاق التذاكر."
+  },
+  "guest": {
+    "created": "تم إنشاء التذكرة. احفظ هذا الرابط للتحقق من حالة تذكرتك.",
+    "reply_sent": "تم إرسال الرد.",
+    "ticket_closed": "هذه التذكرة مغلقة."
+  },
+  "bulk": {
+    "updated": "تم تحديث :count تذكرة."
+  },
+  "rating": {
+    "thank_you": "شكرا لك على ملاحظاتك!",
+    "only_resolved_closed": "يمكنك تقييم التذاكر المحلولة أو المغلقة فقط.",
+    "already_rated": "تم تقييم هذه التذكرة بالفعل."
+  },
+  "admin": {
+    "department_created": "تم إنشاء القسم.",
+    "department_updated": "تم تحديث القسم.",
+    "department_deleted": "تم حذف القسم.",
+    "sla_policy_created": "تم إنشاء سياسة SLA.",
+    "sla_policy_updated": "تم تحديث سياسة SLA.",
+    "sla_policy_deleted": "تم حذف سياسة SLA.",
+    "rule_created": "تم إنشاء القاعدة.",
+    "rule_updated": "تم تحديث القاعدة.",
+    "rule_deleted": "تم حذف القاعدة.",
+    "canned_response_created": "تم إنشاء الرد الجاهز.",
+    "canned_response_updated": "تم تحديث الرد الجاهز.",
+    "canned_response_deleted": "تم حذف الرد الجاهز.",
+    "macro_created": "تم إنشاء الماكرو.",
+    "macro_updated": "تم تحديث الماكرو.",
+    "macro_deleted": "تم حذف الماكرو.",
+    "tag_created": "تم إنشاء الوسم.",
+    "tag_updated": "تم تحديث الوسم.",
+    "tag_deleted": "تم حذف الوسم.",
+    "settings_updated": "تم تحديث الإعدادات."
+  },
+  "middleware": {
+    "not_admin": "ليس لديك صلاحية كمسؤول دعم.",
+    "not_agent": "ليس لديك صلاحية كوكيل دعم."
+  },
+  "inbound": {
+    "disabled": "البريد الإلكتروني الوارد معطّل.",
+    "invalid_signature": "توقيع غير صالح.",
+    "processing_failed": "فشلت المعالجة."
+  },
+  "labels": {
+    "status": {
+      "open": "مفتوح",
+      "in_progress": "قيد التنفيذ",
+      "waiting_on_customer": "بانتظار العميل",
+      "waiting_on_agent": "بانتظار الوكيل",
+      "escalated": "مُصعَّد",
+      "resolved": "تم الحل",
+      "closed": "مغلق",
+      "reopened": "أُعيد فتحه"
+    },
+    "priority": {
+      "low": "منخفض",
+      "medium": "متوسط",
+      "high": "مرتفع",
+      "urgent": "عاجل",
+      "critical": "حرج"
+    }
+  }
+}

--- a/resources/lang/it/messages.json
+++ b/resources/lang/it/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "Risposta inviata.",
+    "note_added": "Nota aggiunta.",
+    "assigned": "Ticket assegnato.",
+    "status_updated": "Stato aggiornato.",
+    "priority_updated": "Priorita aggiornata.",
+    "tags_updated": "Tag aggiornati.",
+    "department_updated": "Reparto aggiornato.",
+    "macro_applied": "Macro \":name\" applicata.",
+    "unfollowed": "Non segui piu il ticket.",
+    "following": "Stai seguendo il ticket.",
+    "note_pinned": "Nota fissata.",
+    "note_unpinned": "Nota rimossa dai fissati.",
+    "pin_notes_only": "Solo le note interne possono essere fissate.",
+    "updated": "Ticket aggiornato.",
+    "created": "Ticket creato con successo.",
+    "closed": "Ticket chiuso.",
+    "reopened": "Ticket riaperto.",
+    "customer_close_forbidden": "I clienti non possono chiudere i ticket."
+  },
+  "guest": {
+    "created": "Ticket creato. Salva questo link per verificare lo stato.",
+    "reply_sent": "Risposta inviata.",
+    "ticket_closed": "Questo ticket e chiuso."
+  },
+  "bulk": {
+    "updated": ":count ticket aggiornato/i."
+  },
+  "rating": {
+    "thank_you": "Grazie per il tuo feedback!",
+    "only_resolved_closed": "Puoi valutare solo ticket risolti o chiusi.",
+    "already_rated": "Questo ticket e gia stato valutato."
+  },
+  "admin": {
+    "department_created": "Reparto creato.",
+    "department_updated": "Reparto aggiornato.",
+    "department_deleted": "Reparto eliminato.",
+    "sla_policy_created": "Policy SLA creata.",
+    "sla_policy_updated": "Policy SLA aggiornata.",
+    "sla_policy_deleted": "Policy SLA eliminata.",
+    "rule_created": "Regola creata.",
+    "rule_updated": "Regola aggiornata.",
+    "rule_deleted": "Regola eliminata.",
+    "canned_response_created": "Risposta predefinita creata.",
+    "canned_response_updated": "Risposta predefinita aggiornata.",
+    "canned_response_deleted": "Risposta predefinita eliminata.",
+    "macro_created": "Macro creata.",
+    "macro_updated": "Macro aggiornata.",
+    "macro_deleted": "Macro eliminata.",
+    "tag_created": "Tag creato.",
+    "tag_updated": "Tag aggiornato.",
+    "tag_deleted": "Tag eliminato.",
+    "settings_updated": "Impostazioni aggiornate."
+  },
+  "middleware": {
+    "not_admin": "Non sei autorizzato come amministratore.",
+    "not_agent": "Non sei autorizzato come agente."
+  },
+  "inbound": {
+    "disabled": "Email in entrata disabilitata.",
+    "invalid_signature": "Firma non valida.",
+    "processing_failed": "Elaborazione fallita."
+  },
+  "labels": {
+    "status": {
+      "open": "Aperto",
+      "in_progress": "In corso",
+      "waiting_on_customer": "In attesa del cliente",
+      "waiting_on_agent": "In attesa dell'agente",
+      "escalated": "Escalato",
+      "resolved": "Risolto",
+      "closed": "Chiuso",
+      "reopened": "Riaperto"
+    },
+    "priority": {
+      "low": "Bassa",
+      "medium": "Media",
+      "high": "Alta",
+      "urgent": "Urgente",
+      "critical": "Critica"
+    }
+  }
+}

--- a/resources/lang/ja/messages.json
+++ b/resources/lang/ja/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "返信を送信しました。",
+    "note_added": "メモを追加しました。",
+    "assigned": "チケットを割り当てました。",
+    "status_updated": "ステータスを更新しました。",
+    "priority_updated": "優先度を更新しました。",
+    "tags_updated": "タグを更新しました。",
+    "department_updated": "部門を更新しました。",
+    "macro_applied": "マクロ「:name」を適用しました。",
+    "unfollowed": "チケットのフォローを解除しました。",
+    "following": "チケットをフォロー中です。",
+    "note_pinned": "メモをピン留めしました。",
+    "note_unpinned": "メモのピン留めを解除しました。",
+    "pin_notes_only": "内部メモのみピン留めできます。",
+    "updated": "チケットを更新しました。",
+    "created": "チケットを正常に作成しました。",
+    "closed": "チケットをクローズしました。",
+    "reopened": "チケットを再開しました。",
+    "customer_close_forbidden": "顧客はチケットをクローズできません。"
+  },
+  "guest": {
+    "created": "チケットを作成しました。このリンクを保存してステータスを確認してください。",
+    "reply_sent": "返信を送信しました。",
+    "ticket_closed": "このチケットはクローズされています。"
+  },
+  "bulk": {
+    "updated": ":count件のチケットを更新しました。"
+  },
+  "rating": {
+    "thank_you": "フィードバックありがとうございます！",
+    "only_resolved_closed": "解決済みまたはクローズ済みのチケットのみ評価できます。",
+    "already_rated": "このチケットは既に評価されています。"
+  },
+  "admin": {
+    "department_created": "部門を作成しました。",
+    "department_updated": "部門を更新しました。",
+    "department_deleted": "部門を削除しました。",
+    "sla_policy_created": "SLAポリシーを作成しました。",
+    "sla_policy_updated": "SLAポリシーを更新しました。",
+    "sla_policy_deleted": "SLAポリシーを削除しました。",
+    "rule_created": "ルールを作成しました。",
+    "rule_updated": "ルールを更新しました。",
+    "rule_deleted": "ルールを削除しました。",
+    "canned_response_created": "定型応答を作成しました。",
+    "canned_response_updated": "定型応答を更新しました。",
+    "canned_response_deleted": "定型応答を削除しました。",
+    "macro_created": "マクロを作成しました。",
+    "macro_updated": "マクロを更新しました。",
+    "macro_deleted": "マクロを削除しました。",
+    "tag_created": "タグを作成しました。",
+    "tag_updated": "タグを更新しました。",
+    "tag_deleted": "タグを削除しました。",
+    "settings_updated": "設定を更新しました。"
+  },
+  "middleware": {
+    "not_admin": "サポート管理者として認可されていません。",
+    "not_agent": "サポートエージェントとして認可されていません。"
+  },
+  "inbound": {
+    "disabled": "受信メールは無効です。",
+    "invalid_signature": "無効な署名です。",
+    "processing_failed": "処理に失敗しました。"
+  },
+  "labels": {
+    "status": {
+      "open": "オープン",
+      "in_progress": "対応中",
+      "waiting_on_customer": "顧客待ち",
+      "waiting_on_agent": "エージェント待ち",
+      "escalated": "エスカレーション済み",
+      "resolved": "解決済み",
+      "closed": "クローズ",
+      "reopened": "再開"
+    },
+    "priority": {
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "urgent": "緊急",
+      "critical": "重大"
+    }
+  }
+}

--- a/resources/lang/ko/messages.json
+++ b/resources/lang/ko/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "답변이 전송되었습니다.",
+    "note_added": "메모가 추가되었습니다.",
+    "assigned": "티켓이 할당되었습니다.",
+    "status_updated": "상태가 업데이트되었습니다.",
+    "priority_updated": "우선순위가 업데이트되었습니다.",
+    "tags_updated": "태그가 업데이트되었습니다.",
+    "department_updated": "부서가 업데이트되었습니다.",
+    "macro_applied": "매크로 \":name\"이(가) 적용되었습니다.",
+    "unfollowed": "티켓 팔로우를 취소했습니다.",
+    "following": "티켓을 팔로우합니다.",
+    "note_pinned": "메모가 고정되었습니다.",
+    "note_unpinned": "메모 고정이 해제되었습니다.",
+    "pin_notes_only": "내부 메모만 고정할 수 있습니다.",
+    "updated": "티켓이 업데이트되었습니다.",
+    "created": "티켓이 성공적으로 생성되었습니다.",
+    "closed": "티켓이 종료되었습니다.",
+    "reopened": "티켓이 다시 열렸습니다.",
+    "customer_close_forbidden": "고객은 티켓을 종료할 수 없습니다."
+  },
+  "guest": {
+    "created": "티켓이 생성되었습니다. 이 링크를 저장하여 티켓 상태를 확인하세요.",
+    "reply_sent": "답변이 전송되었습니다.",
+    "ticket_closed": "이 티켓은 종료되었습니다."
+  },
+  "bulk": {
+    "updated": ":count개의 티켓이 업데이트되었습니다."
+  },
+  "rating": {
+    "thank_you": "피드백 감사합니다!",
+    "only_resolved_closed": "해결되었거나 종료된 티켓만 평가할 수 있습니다.",
+    "already_rated": "이 티켓은 이미 평가되었습니다."
+  },
+  "admin": {
+    "department_created": "부서가 생성되었습니다.",
+    "department_updated": "부서가 업데이트되었습니다.",
+    "department_deleted": "부서가 삭제되었습니다.",
+    "sla_policy_created": "SLA 정책이 생성되었습니다.",
+    "sla_policy_updated": "SLA 정책이 업데이트되었습니다.",
+    "sla_policy_deleted": "SLA 정책이 삭제되었습니다.",
+    "rule_created": "규칙이 생성되었습니다.",
+    "rule_updated": "규칙이 업데이트되었습니다.",
+    "rule_deleted": "규칙이 삭제되었습니다.",
+    "canned_response_created": "정형 응답이 생성되었습니다.",
+    "canned_response_updated": "정형 응답이 업데이트되었습니다.",
+    "canned_response_deleted": "정형 응답이 삭제되었습니다.",
+    "macro_created": "매크로가 생성되었습니다.",
+    "macro_updated": "매크로가 업데이트되었습니다.",
+    "macro_deleted": "매크로가 삭제되었습니다.",
+    "tag_created": "태그가 생성되었습니다.",
+    "tag_updated": "태그가 업데이트되었습니다.",
+    "tag_deleted": "태그가 삭제되었습니다.",
+    "settings_updated": "설정이 업데이트되었습니다."
+  },
+  "middleware": {
+    "not_admin": "지원 관리자 권한이 없습니다.",
+    "not_agent": "지원 상담원 권한이 없습니다."
+  },
+  "inbound": {
+    "disabled": "수신 이메일이 비활성화되어 있습니다.",
+    "invalid_signature": "잘못된 서명입니다.",
+    "processing_failed": "처리에 실패했습니다."
+  },
+  "labels": {
+    "status": {
+      "open": "열림",
+      "in_progress": "진행 중",
+      "waiting_on_customer": "고객 대기",
+      "waiting_on_agent": "상담원 대기",
+      "escalated": "에스컬레이션됨",
+      "resolved": "해결됨",
+      "closed": "종료",
+      "reopened": "재개됨"
+    },
+    "priority": {
+      "low": "낮음",
+      "medium": "보통",
+      "high": "높음",
+      "urgent": "긴급",
+      "critical": "심각"
+    }
+  }
+}

--- a/resources/lang/nl/messages.json
+++ b/resources/lang/nl/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "Antwoord verzonden.",
+    "note_added": "Notitie toegevoegd.",
+    "assigned": "Ticket toegewezen.",
+    "status_updated": "Status bijgewerkt.",
+    "priority_updated": "Prioriteit bijgewerkt.",
+    "tags_updated": "Tags bijgewerkt.",
+    "department_updated": "Afdeling bijgewerkt.",
+    "macro_applied": "Macro \":name\" toegepast.",
+    "unfollowed": "Je volgt dit ticket niet meer.",
+    "following": "Je volgt dit ticket.",
+    "note_pinned": "Notitie vastgezet.",
+    "note_unpinned": "Notitie losgemaakt.",
+    "pin_notes_only": "Alleen interne notities kunnen worden vastgezet.",
+    "updated": "Ticket bijgewerkt.",
+    "created": "Ticket succesvol aangemaakt.",
+    "closed": "Ticket gesloten.",
+    "reopened": "Ticket heropend.",
+    "customer_close_forbidden": "Klanten kunnen tickets niet sluiten."
+  },
+  "guest": {
+    "created": "Ticket aangemaakt. Bewaar deze link om de status te controleren.",
+    "reply_sent": "Antwoord verzonden.",
+    "ticket_closed": "Dit ticket is gesloten."
+  },
+  "bulk": {
+    "updated": ":count ticket(s) bijgewerkt."
+  },
+  "rating": {
+    "thank_you": "Bedankt voor je feedback!",
+    "only_resolved_closed": "Je kunt alleen opgeloste of gesloten tickets beoordelen.",
+    "already_rated": "Dit ticket is al beoordeeld."
+  },
+  "admin": {
+    "department_created": "Afdeling aangemaakt.",
+    "department_updated": "Afdeling bijgewerkt.",
+    "department_deleted": "Afdeling verwijderd.",
+    "sla_policy_created": "SLA-beleid aangemaakt.",
+    "sla_policy_updated": "SLA-beleid bijgewerkt.",
+    "sla_policy_deleted": "SLA-beleid verwijderd.",
+    "rule_created": "Regel aangemaakt.",
+    "rule_updated": "Regel bijgewerkt.",
+    "rule_deleted": "Regel verwijderd.",
+    "canned_response_created": "Standaardantwoord aangemaakt.",
+    "canned_response_updated": "Standaardantwoord bijgewerkt.",
+    "canned_response_deleted": "Standaardantwoord verwijderd.",
+    "macro_created": "Macro aangemaakt.",
+    "macro_updated": "Macro bijgewerkt.",
+    "macro_deleted": "Macro verwijderd.",
+    "tag_created": "Tag aangemaakt.",
+    "tag_updated": "Tag bijgewerkt.",
+    "tag_deleted": "Tag verwijderd.",
+    "settings_updated": "Instellingen bijgewerkt."
+  },
+  "middleware": {
+    "not_admin": "Niet geautoriseerd als beheerder.",
+    "not_agent": "Niet geautoriseerd als medewerker."
+  },
+  "inbound": {
+    "disabled": "Inkomende e-mail is uitgeschakeld.",
+    "invalid_signature": "Ongeldige handtekening.",
+    "processing_failed": "Verwerking mislukt."
+  },
+  "labels": {
+    "status": {
+      "open": "Open",
+      "in_progress": "In behandeling",
+      "waiting_on_customer": "Wachten op klant",
+      "waiting_on_agent": "Wachten op medewerker",
+      "escalated": "Geescaleerd",
+      "resolved": "Opgelost",
+      "closed": "Gesloten",
+      "reopened": "Heropend"
+    },
+    "priority": {
+      "low": "Laag",
+      "medium": "Gemiddeld",
+      "high": "Hoog",
+      "urgent": "Urgent",
+      "critical": "Kritiek"
+    }
+  }
+}

--- a/resources/lang/pl/messages.json
+++ b/resources/lang/pl/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "Odpowiedz wyslana.",
+    "note_added": "Notatka dodana.",
+    "assigned": "Zgloszenie przypisane.",
+    "status_updated": "Status zaktualizowany.",
+    "priority_updated": "Priorytet zaktualizowany.",
+    "tags_updated": "Tagi zaktualizowane.",
+    "department_updated": "Dzial zaktualizowany.",
+    "macro_applied": "Makro \":name\" zastosowane.",
+    "unfollowed": "Przestales obserwowac zgloszenie.",
+    "following": "Obserwujesz zgloszenie.",
+    "note_pinned": "Notatka przypieta.",
+    "note_unpinned": "Notatka odpieta.",
+    "pin_notes_only": "Tylko notatki wewnetrzne moga byc przypiete.",
+    "updated": "Zgloszenie zaktualizowane.",
+    "created": "Zgloszenie utworzone pomyslnie.",
+    "closed": "Zgloszenie zamkniete.",
+    "reopened": "Zgloszenie ponownie otwarte.",
+    "customer_close_forbidden": "Klienci nie moga zamykac zgloszen."
+  },
+  "guest": {
+    "created": "Zgloszenie utworzone. Zapisz ten link.",
+    "reply_sent": "Odpowiedz wyslana.",
+    "ticket_closed": "To zgloszenie jest zamkniete."
+  },
+  "bulk": {
+    "updated": "Zaktualizowano :count zgloszen."
+  },
+  "rating": {
+    "thank_you": "Dziekujemy za opinie!",
+    "only_resolved_closed": "Mozesz oceniac tylko rozwiazane lub zamkniete zgloszenia.",
+    "already_rated": "To zgloszenie zostalo juz ocenione."
+  },
+  "admin": {
+    "department_created": "Dzial utworzony.",
+    "department_updated": "Dzial zaktualizowany.",
+    "department_deleted": "Dzial usuniety.",
+    "sla_policy_created": "Polityka SLA utworzona.",
+    "sla_policy_updated": "Polityka SLA zaktualizowana.",
+    "sla_policy_deleted": "Polityka SLA usunieta.",
+    "rule_created": "Regula utworzona.",
+    "rule_updated": "Regula zaktualizowana.",
+    "rule_deleted": "Regula usunieta.",
+    "canned_response_created": "Gotowa odpowiedz utworzona.",
+    "canned_response_updated": "Gotowa odpowiedz zaktualizowana.",
+    "canned_response_deleted": "Gotowa odpowiedz usunieta.",
+    "macro_created": "Makro utworzone.",
+    "macro_updated": "Makro zaktualizowane.",
+    "macro_deleted": "Makro usuniete.",
+    "tag_created": "Tag utworzony.",
+    "tag_updated": "Tag zaktualizowany.",
+    "tag_deleted": "Tag usuniety.",
+    "settings_updated": "Ustawienia zaktualizowane."
+  },
+  "middleware": {
+    "not_admin": "Brak uprawnien administratora.",
+    "not_agent": "Brak uprawnien agenta."
+  },
+  "inbound": {
+    "disabled": "Poczta przychodzaca wylaczona.",
+    "invalid_signature": "Nieprawidlowy podpis.",
+    "processing_failed": "Przetwarzanie nie powiodlo sie."
+  },
+  "labels": {
+    "status": {
+      "open": "Otwarty",
+      "in_progress": "W toku",
+      "waiting_on_customer": "Oczekiwanie na klienta",
+      "waiting_on_agent": "Oczekiwanie na agenta",
+      "escalated": "Eskalowany",
+      "resolved": "Rozwiazany",
+      "closed": "Zamkniety",
+      "reopened": "Ponownie otwarty"
+    },
+    "priority": {
+      "low": "Niski",
+      "medium": "Sredni",
+      "high": "Wysoki",
+      "urgent": "Pilny",
+      "critical": "Krytyczny"
+    }
+  }
+}

--- a/resources/lang/pt-BR/messages.json
+++ b/resources/lang/pt-BR/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "Resposta enviada.",
+    "note_added": "Nota adicionada.",
+    "assigned": "Chamado atribuido.",
+    "status_updated": "Status atualizado.",
+    "priority_updated": "Prioridade atualizada.",
+    "tags_updated": "Tags atualizadas.",
+    "department_updated": "Departamento atualizado.",
+    "macro_applied": "Macro \":name\" aplicada.",
+    "unfollowed": "Deixou de seguir o chamado.",
+    "following": "Seguindo o chamado.",
+    "note_pinned": "Nota fixada.",
+    "note_unpinned": "Nota desafixada.",
+    "pin_notes_only": "Apenas notas internas podem ser fixadas.",
+    "updated": "Chamado atualizado.",
+    "created": "Chamado criado com sucesso.",
+    "closed": "Chamado fechado.",
+    "reopened": "Chamado reaberto.",
+    "customer_close_forbidden": "Clientes nao podem fechar chamados."
+  },
+  "guest": {
+    "created": "Chamado criado. Salve este link para verificar o status.",
+    "reply_sent": "Resposta enviada.",
+    "ticket_closed": "Este chamado esta fechado."
+  },
+  "bulk": {
+    "updated": ":count chamado(s) atualizado(s)."
+  },
+  "rating": {
+    "thank_you": "Obrigado pelo feedback!",
+    "only_resolved_closed": "Voce so pode avaliar chamados resolvidos ou fechados.",
+    "already_rated": "Este chamado ja foi avaliado."
+  },
+  "admin": {
+    "department_created": "Departamento criado.",
+    "department_updated": "Departamento atualizado.",
+    "department_deleted": "Departamento excluido.",
+    "sla_policy_created": "Politica SLA criada.",
+    "sla_policy_updated": "Politica SLA atualizada.",
+    "sla_policy_deleted": "Politica SLA excluida.",
+    "rule_created": "Regra criada.",
+    "rule_updated": "Regra atualizada.",
+    "rule_deleted": "Regra excluida.",
+    "canned_response_created": "Resposta padrao criada.",
+    "canned_response_updated": "Resposta padrao atualizada.",
+    "canned_response_deleted": "Resposta padrao excluida.",
+    "macro_created": "Macro criada.",
+    "macro_updated": "Macro atualizada.",
+    "macro_deleted": "Macro excluida.",
+    "tag_created": "Tag criada.",
+    "tag_updated": "Tag atualizada.",
+    "tag_deleted": "Tag excluida.",
+    "settings_updated": "Configuracoes atualizadas."
+  },
+  "middleware": {
+    "not_admin": "Nao autorizado como administrador.",
+    "not_agent": "Nao autorizado como agente."
+  },
+  "inbound": {
+    "disabled": "E-mail de entrada desabilitado.",
+    "invalid_signature": "Assinatura invalida.",
+    "processing_failed": "Processamento falhou."
+  },
+  "labels": {
+    "status": {
+      "open": "Aberto",
+      "in_progress": "Em andamento",
+      "waiting_on_customer": "Aguardando cliente",
+      "waiting_on_agent": "Aguardando agente",
+      "escalated": "Escalado",
+      "resolved": "Resolvido",
+      "closed": "Fechado",
+      "reopened": "Reaberto"
+    },
+    "priority": {
+      "low": "Baixa",
+      "medium": "Media",
+      "high": "Alta",
+      "urgent": "Urgente",
+      "critical": "Critica"
+    }
+  }
+}

--- a/resources/lang/ru/messages.json
+++ b/resources/lang/ru/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "Ответ отправлен.",
+    "note_added": "Заметка добавлена.",
+    "assigned": "Заявка назначена.",
+    "status_updated": "Статус обновлен.",
+    "priority_updated": "Приоритет обновлен.",
+    "tags_updated": "Теги обновлены.",
+    "department_updated": "Отдел обновлен.",
+    "macro_applied": "Макрос \":name\" применен.",
+    "unfollowed": "Вы отписались от заявки.",
+    "following": "Вы подписаны на заявку.",
+    "note_pinned": "Заметка закреплена.",
+    "note_unpinned": "Заметка откреплена.",
+    "pin_notes_only": "Можно закрепить только внутренние заметки.",
+    "updated": "Заявка обновлена.",
+    "created": "Заявка успешно создана.",
+    "closed": "Заявка закрыта.",
+    "reopened": "Заявка переоткрыта.",
+    "customer_close_forbidden": "Клиенты не могут закрывать заявки."
+  },
+  "guest": {
+    "created": "Заявка создана. Сохраните эту ссылку для проверки статуса.",
+    "reply_sent": "Ответ отправлен.",
+    "ticket_closed": "Эта заявка закрыта."
+  },
+  "bulk": {
+    "updated": "Обновлено :count заявок."
+  },
+  "rating": {
+    "thank_you": "Спасибо за отзыв!",
+    "only_resolved_closed": "Можно оценивать только решенные или закрытые заявки.",
+    "already_rated": "Эта заявка уже оценена."
+  },
+  "admin": {
+    "department_created": "Отдел создан.",
+    "department_updated": "Отдел обновлен.",
+    "department_deleted": "Отдел удален.",
+    "sla_policy_created": "Политика SLA создана.",
+    "sla_policy_updated": "Политика SLA обновлена.",
+    "sla_policy_deleted": "Политика SLA удалена.",
+    "rule_created": "Правило создано.",
+    "rule_updated": "Правило обновлено.",
+    "rule_deleted": "Правило удалено.",
+    "canned_response_created": "Шаблон ответа создан.",
+    "canned_response_updated": "Шаблон ответа обновлен.",
+    "canned_response_deleted": "Шаблон ответа удален.",
+    "macro_created": "Макрос создан.",
+    "macro_updated": "Макрос обновлен.",
+    "macro_deleted": "Макрос удален.",
+    "tag_created": "Тег создан.",
+    "tag_updated": "Тег обновлен.",
+    "tag_deleted": "Тег удален.",
+    "settings_updated": "Настройки обновлены."
+  },
+  "middleware": {
+    "not_admin": "Нет прав администратора поддержки.",
+    "not_agent": "Нет прав агента поддержки."
+  },
+  "inbound": {
+    "disabled": "Входящая почта отключена.",
+    "invalid_signature": "Недопустимая подпись.",
+    "processing_failed": "Обработка не удалась."
+  },
+  "labels": {
+    "status": {
+      "open": "Открыта",
+      "in_progress": "В работе",
+      "waiting_on_customer": "Ожидание клиента",
+      "waiting_on_agent": "Ожидание агента",
+      "escalated": "Эскалирована",
+      "resolved": "Решена",
+      "closed": "Закрыта",
+      "reopened": "Переоткрыта"
+    },
+    "priority": {
+      "low": "Низкий",
+      "medium": "Средний",
+      "high": "Высокий",
+      "urgent": "Срочный",
+      "critical": "Критический"
+    }
+  }
+}

--- a/resources/lang/tr/messages.json
+++ b/resources/lang/tr/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "Yanit gonderildi.",
+    "note_added": "Not eklendi.",
+    "assigned": "Destek talebi atandi.",
+    "status_updated": "Durum guncellendi.",
+    "priority_updated": "Oncelik guncellendi.",
+    "tags_updated": "Etiketler guncellendi.",
+    "department_updated": "Departman guncellendi.",
+    "macro_applied": "Makro \":name\" uygulandi.",
+    "unfollowed": "Takipten cikarildi.",
+    "following": "Takip ediyorsunuz.",
+    "note_pinned": "Not sabitlendi.",
+    "note_unpinned": "Not sabitleme kaldirildi.",
+    "pin_notes_only": "Yalnizca dahili notlar sabitlenebilir.",
+    "updated": "Destek talebi guncellendi.",
+    "created": "Destek talebi basariyla olusturuldu.",
+    "closed": "Destek talebi kapatildi.",
+    "reopened": "Destek talebi yeniden acildi.",
+    "customer_close_forbidden": "Musteriler destek taleplerini kapatamazlar."
+  },
+  "guest": {
+    "created": "Destek talebi olusturuldu. Bu linki saklayiniz.",
+    "reply_sent": "Yanit gonderildi.",
+    "ticket_closed": "Bu destek talebi kapatilmistir."
+  },
+  "bulk": {
+    "updated": ":count destek talebi guncellendi."
+  },
+  "rating": {
+    "thank_you": "Geri bildiriminiz icin tesekkurler!",
+    "only_resolved_closed": "Yalnizca cozulmus veya kapatilmis destek taleplerini derecelendirebilirsiniz.",
+    "already_rated": "Bu destek talebi zaten derecelendirilmis."
+  },
+  "admin": {
+    "department_created": "Departman olusturuldu.",
+    "department_updated": "Departman guncellendi.",
+    "department_deleted": "Departman silindi.",
+    "sla_policy_created": "SLA Politikasi olusturuldu.",
+    "sla_policy_updated": "SLA Politikasi guncellendi.",
+    "sla_policy_deleted": "SLA Politikasi silindi.",
+    "rule_created": "Kural olusturuldu.",
+    "rule_updated": "Kural guncellendi.",
+    "rule_deleted": "Kural silindi.",
+    "canned_response_created": "Hazir yanit olusturuldu.",
+    "canned_response_updated": "Hazir yanit guncellendi.",
+    "canned_response_deleted": "Hazir yanit silindi.",
+    "macro_created": "Makro olusturuldu.",
+    "macro_updated": "Makro guncellendi.",
+    "macro_deleted": "Makro silindi.",
+    "tag_created": "Etiket olusturuldu.",
+    "tag_updated": "Etiket guncellendi.",
+    "tag_deleted": "Etiket silindi.",
+    "settings_updated": "Ayarlar guncellendi."
+  },
+  "middleware": {
+    "not_admin": "Yonetici yetkisi yok.",
+    "not_agent": "Temsilci yetkisi yok."
+  },
+  "inbound": {
+    "disabled": "Gelen e-posta devre disi.",
+    "invalid_signature": "Gecersiz imza.",
+    "processing_failed": "Isleme basarisiz."
+  },
+  "labels": {
+    "status": {
+      "open": "Acik",
+      "in_progress": "Devam ediyor",
+      "waiting_on_customer": "Musteri bekleniyor",
+      "waiting_on_agent": "Temsilci bekleniyor",
+      "escalated": "Eskalasyon yapildi",
+      "resolved": "Cozuldu",
+      "closed": "Kapatildi",
+      "reopened": "Yeniden acildi"
+    },
+    "priority": {
+      "low": "Dusuk",
+      "medium": "Orta",
+      "high": "Yuksek",
+      "urgent": "Acil",
+      "critical": "Kritik"
+    }
+  }
+}

--- a/resources/lang/zh-CN/messages.json
+++ b/resources/lang/zh-CN/messages.json
@@ -1,0 +1,84 @@
+{
+  "ticket": {
+    "reply_sent": "回复已发送。",
+    "note_added": "备注已添加。",
+    "assigned": "工单已分配。",
+    "status_updated": "状态已更新。",
+    "priority_updated": "优先级已更新。",
+    "tags_updated": "标签已更新。",
+    "department_updated": "部门已更新。",
+    "macro_applied": "宏\":name\"已应用。",
+    "unfollowed": "已取消关注工单。",
+    "following": "正在关注工单。",
+    "note_pinned": "备注已置顶。",
+    "note_unpinned": "备注已取消置顶。",
+    "pin_notes_only": "只有内部备注可以置顶。",
+    "updated": "工单已更新。",
+    "created": "工单创建成功。",
+    "closed": "工单已关闭。",
+    "reopened": "工单已重新打开。",
+    "customer_close_forbidden": "客户无法关闭工单。"
+  },
+  "guest": {
+    "created": "工单已创建。保存此链接以查看工单状态。",
+    "reply_sent": "回复已发送。",
+    "ticket_closed": "此工单已关闭。"
+  },
+  "bulk": {
+    "updated": "已更新:count个工单。"
+  },
+  "rating": {
+    "thank_you": "感谢您的反馈！",
+    "only_resolved_closed": "您只能评价已解决或已关闭的工单。",
+    "already_rated": "此工单已被评价。"
+  },
+  "admin": {
+    "department_created": "部门已创建。",
+    "department_updated": "部门已更新。",
+    "department_deleted": "部门已删除。",
+    "sla_policy_created": "SLA策略已创建。",
+    "sla_policy_updated": "SLA策略已更新。",
+    "sla_policy_deleted": "SLA策略已删除。",
+    "rule_created": "规则已创建。",
+    "rule_updated": "规则已更新。",
+    "rule_deleted": "规则已删除。",
+    "canned_response_created": "预设回复已创建。",
+    "canned_response_updated": "预设回复已更新。",
+    "canned_response_deleted": "预设回复已删除。",
+    "macro_created": "宏已创建。",
+    "macro_updated": "宏已更新。",
+    "macro_deleted": "宏已删除。",
+    "tag_created": "标签已创建。",
+    "tag_updated": "标签已更新。",
+    "tag_deleted": "标签已删除。",
+    "settings_updated": "设置已更新。"
+  },
+  "middleware": {
+    "not_admin": "未获授权为支持管理员。",
+    "not_agent": "未获授权为支持客服。"
+  },
+  "inbound": {
+    "disabled": "入站邮件已禁用。",
+    "invalid_signature": "无效签名。",
+    "processing_failed": "处理失败。"
+  },
+  "labels": {
+    "status": {
+      "open": "打开",
+      "in_progress": "处理中",
+      "waiting_on_customer": "等待客户",
+      "waiting_on_agent": "等待客服",
+      "escalated": "已升级",
+      "resolved": "已解决",
+      "closed": "已关闭",
+      "reopened": "已重开"
+    },
+    "priority": {
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "urgent": "紧急",
+      "critical": "严重"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add JSON locale files for ar, it, ja, ko, nl, pl, pt-BR, ru, tr, zh-CN
- Translations cover ticket messages, admin actions, middleware, labels

## Test plan
- [ ] Verify JSON syntax validity
- [ ] Spot-check translations