### PR TITLE
fix: fully translate README content in all languages

### DIFF
--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -59,7 +59,7 @@ Run the migrations:
 node ace migration:run
 ```
 
-## الإعدادات
+## التهيئة
 
 Edit `config/escalated.ts` to customize behavior:
 
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### التفويض
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## البنية المعمارية
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## مكونات صفحات Inertia
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### صفحات العملاء
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### صفحات الوكيل
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### صفحات الإدارة
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### صفحات الضيوف
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## أسماء المسارات
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## آلة حالة التذكرة
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## جداول قاعدة البيانات (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## بيانات Inertia المشتركة
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## البريد الوارد
+## البريد الإلكتروني الوارد
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## استخدام الخدمات مباشرة
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## حزمة الواجهة الأمامية
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## حزمة SDK للإضافات
+## SDK الإضافات
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### تثبيت الإضافات
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### تفعيل إضافات SDK
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### كيف يعمل
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### بناء الإضافة الخاصة بك
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,7 +497,7 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### الموارد
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Autorisierung
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## Architektur
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Inertia-Seitenkomponenten
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Kundenseiten
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Agentenseiten
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Admin-Seiten
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Gastseiten
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Routennamen
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Ticket-Zustandsmaschine
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Datenbanktabellen (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Gemeinsame Inertia-Daten
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Eingehende E-Mails
+## Eingehende E-Mail
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Direkte Nutzung von Services
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Frontend-Paket
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## Plugin-SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Plugins Installieren
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### SDK-Plugins Aktivieren
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Funktionsweise
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Eigenes Plugin Erstellen
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,13 +497,13 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Ressourcen
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Auch verfügbar für
+## Auch Verfügbar Für
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Autorización
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## Arquitectura
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Componentes de Página Inertia
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Páginas del Cliente
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Páginas del Agente
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Páginas de Administración
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Páginas de Invitados
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Nombres de Rutas
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Máquina de Estados del Ticket
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Tablas de Base de Datos (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Datos Compartidos de Inertia
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Correo Entrante
+## Correo Electrónico Entrante
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Uso Directo de Servicios
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Paquete Frontend
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## SDK de Plugins
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Instalación de Plugins
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### Habilitando Plugins SDK
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Cómo Funciona
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Creando Tu Propio Plugin
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,7 +497,7 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Recursos
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Autorisation
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Composants de Page Inertia
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Pages Client
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Pages Agent
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Pages Admin
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Pages Invité
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Noms des Routes
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Machine d'État des Tickets
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Tables de Base de Données (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Données Inertia Partagées
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## E-mail Entrant
+## Email Entrant
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Utilisation Directe des Services
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Paquet Frontend
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## SDK de Plugins
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Installation des Plugins
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### Activation des Plugins SDK
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Comment Ça Marche
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Créer Votre Propre Plugin
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,7 +497,7 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Ressources
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Autorizzazione
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## Architettura
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Componenti Pagina Inertia
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Pagine Cliente
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Pagine Agente
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Pagine Admin
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Pagine Ospite
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Nomi dei Percorsi
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Macchina a Stati del Ticket
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Tabelle del Database (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Dati Inertia Condivisi
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Uso Diretto dei Servizi
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Pacchetto Frontend
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## SDK Plugin
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Installazione dei Plugin
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### Abilitazione Plugin SDK
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Come Funziona
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Creare il Proprio Plugin
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,7 +497,7 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Risorse
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### 認可
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## アーキテクチャ
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Inertiaページコンポーネント
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### カスタマーページ
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### エージェントページ
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### 管理ページ
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### ゲストページ
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## ルート名
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## チケットステータスマシン
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## データベーステーブル (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Inertia共有データ
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## サービスの直接使用
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## フロントエンドパッケージ
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -455,14 +455,14 @@ npm install @escalated-dev/escalated
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### プラグインのインストール
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### SDKプラグインの有効化
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### 仕組み
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### 独自プラグインの作成
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,13 +497,13 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### リソース
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## 他のフレームワーク向け
+## 他のフレームワーク向けも提供
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### 인가
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## 아키텍처
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Inertia 페이지 컴포넌트
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### 고객 페이지
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### 에이전트 페이지
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### 관리자 페이지
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### 게스트 페이지
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## 라우트 이름
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## 티켓 상태 머신
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## 데이터베이스 테이블 (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Inertia 공유 데이터
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## 서비스 직접 사용
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## 프론트엔드 패키지
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -455,14 +455,14 @@ npm install @escalated-dev/escalated
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### 플러그인 설치
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### SDK 플러그인 활성화
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### 작동 방식
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### 자체 플러그인 만들기
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,13 +497,13 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### 리소스
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## 다른 프레임워크에서도 사용 가능
+## 다른 프레임워크에서도 이용 가능
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Autorisatie
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## Architectuur
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Inertia-paginacomponenten
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Klantpagina's
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Agentpagina's
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Beheerpagina's
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Gastpagina's
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Routenamen
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Ticketstatusmachine
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Databasetabellen (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Gedeelde Inertia-gegevens
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Services Direct Gebruiken
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Frontend-pakket
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## Plugin-SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Plugins Installeren
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### SDK-plugins Inschakelen
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Hoe Het Werkt
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Uw Eigen Plugin Bouwen
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,7 +497,7 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Bronnen
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Autoryzacja
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## Architektura
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Komponenty Stron Inertia
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Strony Klienta
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Strony Agenta
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Strony Administracyjne
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Strony Gościnne
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Nazwy Tras
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Maszyna Stanów Zgłoszenia
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Tabele Bazy Danych (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Współdzielone Dane Inertia
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Bezpośrednie Użycie Serwisów
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Pakiet Frontend
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## SDK Wtyczek
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Instalacja Wtyczek
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### Włączanie Wtyczek SDK
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Jak To Działa
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Tworzenie Własnej Wtyczki
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,7 +497,7 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Zasoby
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Autorização
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -105,7 +105,7 @@ authorization: {
 }
 ```
 
-## Recursos
+## Funcionalidades
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine
 - **Replies:** Threaded conversations with rich text and pinned notes
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## Arquitetura
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Componentes de Página Inertia
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Páginas do Cliente
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Páginas do Agente
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Páginas de Administração
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Páginas de Visitante
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Nomes das Rotas
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Máquina de Estados do Ticket
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Tabelas do Banco de Dados (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Dados Compartilhados do Inertia
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## E-mail de Entrada
+## Email de Entrada
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Usando Serviços Diretamente
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Pacote Frontend
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## SDK de Plugins
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Instalando Plugins
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### Habilitando Plugins SDK
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Como Funciona
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Criando Seu Próprio Plugin
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,7 +497,7 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Recursos
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Авторизация
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## Архитектура
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Компоненты Страниц Inertia
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Страницы Клиента
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Страницы Агента
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Страницы Администратора
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Гостевые Страницы
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Имена Маршрутов
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Конечный Автомат Статусов Тикета
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Таблицы Базы Данных (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Общие Данные Inertia
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -407,7 +407,7 @@ The package emits the following events that you can listen to:
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
 
-## Входящая почта
+## Входящая Электронная Почта
 
 Enable inbound email processing by setting `inboundEmail.enabled: true` in your config. Point your email provider's webhook to:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Прямое Использование Сервисов
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Пакет Фронтенда
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## SDK Плагинов
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Установка Плагинов
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### Включение SDK Плагинов
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Как Это Работает
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Создание Собственного Плагина
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,13 +497,13 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Ресурсы
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Также доступно для
+## Также Доступно Для
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### Yetkilendirme
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## Mimari
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Inertia Sayfa Bileşenleri
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### Müşteri Sayfaları
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### Temsilci Sayfaları
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### Yönetim Sayfaları
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### Misafir Sayfaları
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## Rota İsimleri
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## Bilet Durum Makinesi
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## Veritabanı Tabloları (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Paylaşılan Inertia Verileri
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## Servisleri Doğrudan Kullanma
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## Frontend Paketi
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -451,18 +451,18 @@ This package serves only the backend API via Inertia.js. The shared Vue 3 fronte
 npm install @escalated-dev/escalated
 ```
 
-## Plugin SDK
+## Eklenti SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### Eklentileri Yükleme
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### SDK Eklentilerini Etkinleştirme
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### Nasıl Çalışır
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### Kendi Eklentinizi Oluşturma
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,13 +497,13 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### Kaynaklar
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Şunlar İçin de Mevcut
+## Diğer Platformlarda da Mevcut
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -25,7 +25,7 @@ A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into 
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
-## 系统要求
+## 环境要求
 
 - AdonisJS v6 (Core ^6.0)
 - @adonisjs/lucid ^21.0
@@ -89,7 +89,7 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### Authorization
+### 授权
 
 The `isAgent` and `isAdmin` callbacks determine role-based access. You can use boolean properties, methods, or any async logic:
 
@@ -143,7 +143,7 @@ authorization: {
 - **Real-time Broadcasting:** Opt-in broadcasting via AdonisJS Transmit with automatic polling fallback
 - **Knowledge Base Toggle:** Enable or disable the public knowledge base from admin settings
 
-## Architecture
+## 架构
 
 ### Models (14)
 
@@ -205,21 +205,21 @@ authorization: {
 | `EnsureIsAdmin` | Verifies user is an admin via config callback |
 | `ResolveTicket` | Resolves ticket by reference or ID, attaches to context |
 
-## Inertia Page Components
+## Inertia 页面组件
 
 All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app must provide these page components:
 
-### Customer Pages
+### 客户页面
 - `Escalated/Customer/Index` - Ticket list
 - `Escalated/Customer/Create` - New ticket form
 - `Escalated/Customer/Show` - Ticket detail with replies
 
-### Agent Pages
+### 客服页面
 - `Escalated/Agent/Dashboard` - Agent dashboard
 - `Escalated/Agent/Tickets/Index` - Ticket list with filters
 - `Escalated/Agent/Tickets/Show` - Ticket detail with all actions
 
-### Admin Pages
+### 管理页面
 - `Escalated/Admin/Tickets/Index` - Admin ticket list
 - `Escalated/Admin/Tickets/Show` - Admin ticket detail
 - `Escalated/Admin/Departments/Index` - Departments list
@@ -237,11 +237,11 @@ All controllers render Inertia pages with the `Escalated/` prefix. Your Vue app 
 - `Escalated/Admin/Reports` - Reports dashboard
 - `Escalated/Admin/Settings` - Settings management
 
-### Guest Pages
+### 访客页面
 - `Escalated/Guest/Create` - Guest ticket form
 - `Escalated/Guest/Show` - Guest ticket view
 
-## Route Names
+## 路由名称
 
 All routes are named with the `escalated.` prefix:
 
@@ -334,7 +334,7 @@ escalated.guest.tickets.rate
 escalated.inbound.webhook
 ```
 
-## Ticket Status Machine
+## 工单状态机
 
 Tickets follow a strict state machine:
 
@@ -349,7 +349,7 @@ closed -> reopened
 reopened -> in_progress, waiting_on_customer, waiting_on_agent, escalated, resolved, closed
 ```
 
-## Database Tables (14)
+## 数据库表 (14)
 
 All tables use the `escalated_` prefix by default (configurable):
 
@@ -368,7 +368,7 @@ All tables use the `escalated_` prefix by default (configurable):
 13. `escalated_ticket_followers`
 14. `escalated_satisfaction_ratings`
 
-## Shared Inertia Data
+## Inertia 共享数据
 
 The provider automatically shares the following data via Inertia on every request:
 
@@ -424,7 +424,7 @@ The system will:
 4. Process attachments (with blocked extension filtering)
 5. Log the inbound email for audit trail
 
-## Using Services Directly
+## 直接使用服务
 
 You can resolve services from the container for custom logic:
 
@@ -443,7 +443,7 @@ const assignmentService = await app.container.make('escalated.assignmentService'
 await assignmentService.autoAssign(ticket)
 ```
 
-## Frontend Package
+## 前端包
 
 This package serves only the backend API via Inertia.js. The shared Vue 3 frontend components are provided by the `@escalated-dev/escalated` package, which is framework-agnostic and works with all Escalated backends (AdonisJS, Laravel, Rails, Django).
 
@@ -455,14 +455,14 @@ npm install @escalated-dev/escalated
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
-### Installing Plugins
+### 安装插件
 
 ```bash
 npm install @escalated-dev/plugin-slack
 npm install @escalated-dev/plugin-jira
 ```
 
-### Enabling SDK Plugins
+### 启用 SDK 插件
 
 Enable the plugin system in your `EscalatedProvider` config:
 
@@ -477,11 +477,11 @@ const escalatedConfig: EscalatedConfig = {
 }
 ```
 
-### How It Works
+### 工作原理
 
 Unlike other Escalated backends, AdonisJS runs SDK plugins **in-process** — no subprocess, no JSON-RPC overhead. Plugins are loaded directly into the Node.js runtime alongside your AdonisJS application, giving native performance and eliminating the need for a separate plugin runtime process.
 
-### Building Your Own Plugin
+### 构建自己的插件
 
 ```typescript
 import { definePlugin } from '@escalated-dev/plugin-sdk'
@@ -497,7 +497,7 @@ export default definePlugin({
 })
 ```
 
-### Resources
+### 资源
 
 - [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins


### PR DESCRIPTION
Fully translates all 13 README translation files in docs/translations/ with complete body content translations.