### PR TITLE
fix: include url in attachment serialization

### DIFF
--- a/src/controllers/admin_tickets_controller.ts
+++ b/src/controllers/admin_tickets_controller.ts
@@ -69,12 +69,19 @@ export default class AdminTicketsController {
     await ticket.load('satisfactionRating')
     await ticket.load((loader: any) => {
       loader.load('replies', (query: any) => {
-        query.orderBy('created_at', 'desc')
+        query.preload('attachments').orderBy('created_at', 'desc')
       })
       loader.load('activities', (query: any) => {
         query.orderBy('created_at', 'desc').limit(20)
       })
     })
+
+    // Resolve attachment URLs (url() is async on the Attachment model)
+    for (const reply of ticket.replies ?? []) {
+      for (const attachment of reply.attachments ?? []) {
+        ;(attachment as any).$extras.url = await attachment.url()
+      }
+    }
 
     const departments = await Department.query()
       .withScopes((scopes) => scopes.active())

--- a/src/controllers/agent_tickets_controller.ts
+++ b/src/controllers/agent_tickets_controller.ts
@@ -67,12 +67,19 @@ export default class AgentTicketsController {
     await ticket.load('satisfactionRating')
     await ticket.load((loader: any) => {
       loader.load('replies', (query: any) => {
-        query.orderBy('created_at', 'desc')
+        query.preload('attachments').orderBy('created_at', 'desc')
       })
       loader.load('activities', (query: any) => {
         query.orderBy('created_at', 'desc').limit(20)
       })
     })
+
+    // Resolve attachment URLs (url() is async on the Attachment model)
+    for (const reply of ticket.replies ?? []) {
+      for (const attachment of reply.attachments ?? []) {
+        ;(attachment as any).$extras.url = await attachment.url()
+      }
+    }
 
     const departments = await Department.query()
       .withScopes((scopes) => scopes.active())

--- a/src/controllers/api/api_ticket_controller.ts
+++ b/src/controllers/api/api_ticket_controller.ts
@@ -57,7 +57,7 @@ export default class ApiTicketController {
     await ticket.load('satisfactionRating')
     await ticket.load((loader: any) => {
       loader.load('replies', (query: any) => {
-        query.orderBy('created_at', 'desc')
+        query.preload('attachments').orderBy('created_at', 'desc')
       })
       loader.load('activities', (query: any) => {
         query.orderBy('created_at', 'desc').limit(20)
@@ -65,7 +65,7 @@ export default class ApiTicketController {
     })
 
     return ctx.response.json({
-      data: this.formatTicketDetail(ticket),
+      data: await this.formatTicketDetail(ticket),
     })
   }
 
@@ -98,7 +98,7 @@ export default class ApiTicketController {
     await ticket.load('tags')
 
     return ctx.response.created({
-      data: this.formatTicketDetail(ticket),
+      data: await this.formatTicketDetail(ticket),
       message: 'Ticket created.',
     })
   }
@@ -336,7 +336,7 @@ export default class ApiTicketController {
    * Format a ticket for detail (show) responses.
    * Matches the Laravel TicketResource output.
    */
-  protected formatTicketDetail(ticket: Ticket): Record<string, any> {
+  protected async formatTicketDetail(ticket: Ticket): Promise<Record<string, any>> {
     const data: Record<string, any> = {
       id: ticket.id,
       reference: ticket.reference,
@@ -365,23 +365,25 @@ export default class ApiTicketController {
           name: tag.name,
           color: tag.color,
         })) ?? [],
-      replies:
-        ticket.replies?.map((r: any) => ({
+      replies: await Promise.all(
+        (ticket.replies ?? []).map(async (r: any) => ({
           id: r.id,
           body: r.body,
           is_internal_note: r.isInternalNote,
           is_pinned: r.isPinned ?? false,
           author: null, // Author loaded separately via user model
-          attachments:
-            r.attachments?.map((a: any) => ({
+          attachments: await Promise.all(
+            (r.attachments ?? []).map(async (a: any) => ({
               id: a.id,
               filename: a.filename,
               mime_type: a.mimeType,
               size: a.size,
-              url: a.url,
-            })) ?? [],
+              url: await a.url(),
+            }))
+          ),
           created_at: r.createdAt.toISO(),
-        })) ?? [],
+        }))
+      ),
       activities:
         ticket.activities?.map((a: any) => ({
           id: a.id,

--- a/src/controllers/customer_tickets_controller.ts
+++ b/src/controllers/customer_tickets_controller.ts
@@ -74,9 +74,16 @@ export default class CustomerTicketsController {
     await ticket.load('tags')
     await ticket.load((loader: any) => {
       loader.load('replies', (query: any) => {
-        query.where('is_internal_note', false).orderBy('created_at', 'desc')
+        query.preload('attachments').where('is_internal_note', false).orderBy('created_at', 'desc')
       })
     })
+
+    // Resolve attachment URLs (url() is async on the Attachment model)
+    for (const reply of ticket.replies ?? []) {
+      for (const attachment of reply.attachments ?? []) {
+        ;(attachment as any).$extras.url = await attachment.url()
+      }
+    }
 
     return getRenderer().render(ctx, 'Escalated/Customer/Show', {
       ticket,

--- a/src/controllers/guest_tickets_controller.ts
+++ b/src/controllers/guest_tickets_controller.ts
@@ -89,9 +89,16 @@ export default class GuestTicketsController {
     await ticket.load('department')
     await ticket.load((loader: any) => {
       loader.load('replies', (query: any) => {
-        query.where('is_internal_note', false).orderBy('created_at', 'desc')
+        query.preload('attachments').where('is_internal_note', false).orderBy('created_at', 'desc')
       })
     })
+
+    // Resolve attachment URLs (url() is async on the Attachment model)
+    for (const reply of ticket.replies ?? []) {
+      for (const attachment of reply.attachments ?? []) {
+        ;(attachment as any).$extras.url = await attachment.url()
+      }
+    }
 
     return getRenderer().render(ctx, 'Escalated/Guest/Show', {
       ticket,


### PR DESCRIPTION
## Summary
- Fixes escalated-dev/escalated#26 — attachment `url` was missing from serialized output
- Fixed `a.url` → `await a.url()` in API controller (was returning method ref instead of resolved URL)
- Added `.preload('attachments')` to reply queries in all 4 Inertia controllers
- Resolved attachment URLs stored in `$extras.url` for Lucid JSON serialization

## Test plan
- [ ] Verify ticket and reply attachments include working `url` in Inertia views
- [ ] Verify API ticket detail returns correct attachment URLs