### PR TITLE
fix: add luxon + xmldom runtime deps + build:emit escape hatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "@escalated-dev/escalated-adonis",
       "version": "0.5.0",
       "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.13",
+        "luxon": "^3.7.2"
+      },
       "devDependencies": {
         "@adonisjs/auth": "^9.2.0",
         "@adonisjs/cache": "^1.0.0",
@@ -2962,6 +2966,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -6103,6 +6116,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -30,12 +30,17 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:emit": "tsc --noEmitOnError false || true",
     "dev": "tsc --watch",
     "clean": "rm -rf build",
     "test": "node --test tests/*.test.js",
     "lint": "eslint .",
     "format:check": "prettier --check .",
     "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@xmldom/xmldom": "^0.8.13",
+    "luxon": "^3.7.2"
   },
   "prettier": "@adonisjs/prettier-config",
   "keywords": [


### PR DESCRIPTION
## Summary

Two related package fixes:

1. **Add missing runtime deps.** `luxon` is imported by workflow_engine, sla_service, and several controllers; `@xmldom/xmldom` is imported by sso_service for SAML XML parsing. Neither was declared, so every install dropped them and any consumer hit `MODULE_NOT_FOUND` at runtime.

2. **Add `build:emit` script** (`tsc --noEmitOnError false || true`) as a pragmatic unblock so the package produces a usable JS artifact even while the broader type-safety cleanup (#34: 312 remaining errors) is in progress. Production builds should still use `npm run build`.

This reduces the typecheck error count from 314 → 312. The remaining errors (`Property X does not exist on type 'never'` on Lucid model relations, `Argument of type \"escalated:*\" is not assignable to keyof EventsList`) are real bugs but require source changes — separate PRs.

## Test plan
- [x] Tarball produced via `npm pack` after `npm run build:emit` is installable in a fresh AdonisJS app
- [ ] CI green