### PR TITLE
fix: use /helpers/string subpath for string helper import

### DIFF
--- a/src/controllers/guest_tickets_controller.ts
+++ b/src/controllers/guest_tickets_controller.ts
@@ -1,6 +1,6 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import emitter from '@adonisjs/core/services/emitter'
-import { string } from '@adonisjs/core/helpers'
+import string from '@adonisjs/core/helpers/string'
 import Ticket from '../models/ticket.js'
 import Reply from '../models/reply.js'
 import Department from '../models/department.js'

--- a/src/models/department.ts
+++ b/src/models/department.ts
@@ -1,7 +1,7 @@
 import { type DateTime } from 'luxon'
 import { BaseModel, column, hasMany, scope, beforeCreate } from '@adonisjs/lucid/orm'
 import type { HasMany } from '@adonisjs/lucid/types/relations'
-import { string } from '@adonisjs/core/helpers'
+import string from '@adonisjs/core/helpers/string'
 import Ticket from './ticket.js'
 
 export default class Department extends BaseModel {

--- a/src/models/tag.ts
+++ b/src/models/tag.ts
@@ -1,7 +1,7 @@
 import { type DateTime } from 'luxon'
 import { BaseModel, column, manyToMany, beforeCreate } from '@adonisjs/lucid/orm'
 import type { ManyToMany } from '@adonisjs/lucid/types/relations'
-import { string } from '@adonisjs/core/helpers'
+import string from '@adonisjs/core/helpers/string'
 import Ticket from './ticket.js'
 
 export default class Tag extends BaseModel {

--- a/src/services/import_service.ts
+++ b/src/services/import_service.ts
@@ -14,7 +14,7 @@
 */
 
 import { DateTime } from 'luxon'
-import { string } from '@adonisjs/core/helpers'
+import string from '@adonisjs/core/helpers/string'
 import type ImportJob from '../models/import_job.js'
 import ImportSourceMap from '../models/import_source_map.js'
 import ImportContext from '../support/import_context.js'


### PR DESCRIPTION
## Summary

@adonisjs/core@6 doesn't re-export the \`string\` helper from the top-level \`@adonisjs/core/helpers\` — only from \`/helpers/string\`. The package's 4 call sites used the (older/wrong) top-level form, which **compiles** fine (TS can still resolve the type) but **fails at runtime**:

\`\`\`
SyntaxError: The requested module '@adonisjs/core/helpers'
does not provide an export named 'string'
    at file:///host/node_modules/@escalated-dev/escalated-adonis/build/src/models/tag.js:11
\`\`\`

Switched all four call sites from \`import { string } from '@adonisjs/core/helpers'\` to \`import string from '@adonisjs/core/helpers/string'\`. Behaviour is identical.

## Affected files
- src/controllers/guest_tickets_controller.ts
- src/models/department.ts
- src/models/tag.ts
- src/services/import_service.ts