### PR TITLE
fix(deps): install @escalated-dev/plugin-sdk via codeload tarball — 114 → 70 TS errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
+        "@escalated-dev/plugin-sdk": "https://codeload.github.com/escalated-dev/escalated-plugin-sdk/tar.gz/refs/tags/v0.1.2",
         "@xmldom/xmldom": "^0.8.13",
         "luxon": "^3.7.2"
       },
@@ -1383,6 +1384,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@escalated-dev/plugin-sdk": {
+      "version": "0.1.0",
+      "resolved": "https://codeload.github.com/escalated-dev/escalated-plugin-sdk/tar.gz/refs/tags/v0.1.2",
+      "integrity": "sha512-Eko0ssBn2jFEFaRmcFbOoeh/UZNqY46ds7ROI/mVfYy8Lrj9oUsVz6GTfVULIx6ADWLS0jkOSsjmgfyJJQr8UQ==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@escalated-dev/plugin-sdk": "https://codeload.github.com/escalated-dev/escalated-plugin-sdk/tar.gz/refs/tags/v0.1.2",
     "@xmldom/xmldom": "^0.8.13",
     "luxon": "^3.7.2"
   },


### PR DESCRIPTION
## Summary

The plugin bridge (`src/bridge/*.ts`), dispatcher and route registrar all import from `@escalated-dev/plugin-sdk`. The package lives at https://github.com/escalated-dev/escalated-plugin-sdk and is not yet published to npm, so it was unresolvable at build time:

- 6 direct `TS2307: Cannot find module '@escalated-dev/plugin-sdk'`
- ~38 cascading `TS7006: Parameter implicitly has an 'any' type` and similar across bridge code

Pin to **v0.1.2** of the SDK ([escalated-plugin-sdk#7](https://github.com/escalated-dev/escalated-plugin-sdk/pull/7) ships the `build/` artifacts in git; [#8](https://github.com/escalated-dev/escalated-plugin-sdk/pull/8) drops the prepare hook).

Use the **codeload tarball URL** rather than the `github:` shorthand because npm 11 spawns the git-prepare child install with both `--prefer-offline=false` AND `--prefer-online=false` and then rejects them as mutually exclusive — a known npm regression. Codeload tarball URLs bypass the git-prepare path entirely and install cleanly on every npm version.

## Effect

`tsc --noEmit` errors drop from **114 → 70**. The remaining 70 split into real code issues tracked individually in #34:

- 38 TS2339 (`property does not exist`) — narrower set than before, no longer cascading from `never`
- 16 TS2769 (overload mismatches) — Lucid query builder edge cases
- 6 TS18046 (`X is unknown`)
- 3 TS2307 (`Cannot find module`) — `#start/env`, `@adonisjs/transmit/services/main`, `adm-zip`
- Misc small (configure.publishMigrations, etc.)

Each will be a focused follow-up PR.

## Test plan

- [x] `rm -rf node_modules/@escalated-dev && npm install` — succeeds, `node_modules/@escalated-dev/plugin-sdk/build/` present with the expected `.js` + `.d.ts` files
- [x] `tsc --noEmit` errors: 114 → 70
- [x] No runtime change beyond the new dep