### PR TITLE
fix(configure): replace removed command.publishMigrations API

### DIFF
--- a/configure.ts
+++ b/configure.ts
@@ -9,6 +9,9 @@
 |
 */
 
+import { copyFile, mkdir, readdir } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import type ConfigureCommand from '@adonisjs/core/commands/configure'
 import { stubsRoot } from './stubs/main.js'
 
@@ -29,12 +32,52 @@ export async function configure(command: ConfigureCommand) {
 
   /**
    * Publish migrations
+   *
+   * AdonisJS 6 removed `command.publishMigrations`. Replicate its behaviour
+   * with `node:fs/promises`: copy every shipped migration into the host
+   * app's `database/migrations/` directory with a unique timestamp prefix so
+   * the migrator runs them after the host's own migrations.
+   *
+   * Idempotent: if a file ending in `_<basename>` already exists in the
+   * target directory, skip it (unless `--force`).
    */
-  await command.publishMigrations({
-    from: new URL('./database/migrations', import.meta.url),
-    to: command.app.migrationsPath(),
-  })
+  await publishMigrations(command)
 
   command.logger.success('Escalated configured successfully!')
   command.logger.info('Run "node ace migration:run" to create the escalated tables.')
+}
+
+async function publishMigrations(command: ConfigureCommand): Promise<void> {
+  const sourceDir = fileURLToPath(new URL('./database/migrations', import.meta.url))
+  const targetDir = command.app.migrationsPath()
+
+  await mkdir(targetDir, { recursive: true })
+
+  const sourceFiles = (await readdir(sourceDir))
+    .filter((name) => name.endsWith('.ts'))
+    .sort()
+
+  const existing = new Set(
+    (await readdir(targetDir).catch(() => [])).filter((name) => name.endsWith('.ts'))
+  )
+
+  const force = !!command.parsedFlags.force
+  const baseTimestamp = Date.now()
+
+  for (let i = 0; i < sourceFiles.length; i++) {
+    const sourceName = sourceFiles[i]
+    const cleanBasename = sourceName.replace(/^\d+_/, '')
+
+    if (!force) {
+      const alreadyPublished = [...existing].some((name) => name.endsWith(`_${cleanBasename}`))
+      if (alreadyPublished) {
+        command.logger.info(`skip ${cleanBasename} (already published)`)
+        continue
+      }
+    }
+
+    const targetName = `${baseTimestamp + i}_${cleanBasename}`
+    await copyFile(join(sourceDir, sourceName), join(targetDir, targetName))
+    command.logger.action(`create database/migrations/${targetName}`).succeeded()
+  }
 }

--- a/configure.ts
+++ b/configure.ts
@@ -53,31 +53,31 @@ async function publishMigrations(command: ConfigureCommand): Promise<void> {
 
   await mkdir(targetDir, { recursive: true })
 
-  const sourceFiles = (await readdir(sourceDir))
-    .filter((name) => name.endsWith('.ts'))
-    .sort()
+  const sourceEntries = await readdir(sourceDir)
+  const sourceFiles = sourceEntries.filter((name) => name.endsWith('.ts')).sort()
 
-  const existing = new Set(
-    (await readdir(targetDir).catch(() => [])).filter((name) => name.endsWith('.ts'))
-  )
+  const targetEntries = await readdir(targetDir).catch((): string[] => [])
+  const existing = new Set(targetEntries.filter((name) => name.endsWith('.ts')))
 
   const force = !!command.parsedFlags.force
   const baseTimestamp = Date.now()
 
-  for (let i = 0; i < sourceFiles.length; i++) {
-    const sourceName = sourceFiles[i]
+  let offset = 0
+  for (const sourceName of sourceFiles) {
     const cleanBasename = sourceName.replace(/^\d+_/, '')
 
     if (!force) {
       const alreadyPublished = [...existing].some((name) => name.endsWith(`_${cleanBasename}`))
       if (alreadyPublished) {
         command.logger.info(`skip ${cleanBasename} (already published)`)
+        offset += 1
         continue
       }
     }
 
-    const targetName = `${baseTimestamp + i}_${cleanBasename}`
+    const targetName = `${baseTimestamp + offset}_${cleanBasename}`
     await copyFile(join(sourceDir, sourceName), join(targetDir, targetName))
     command.logger.action(`create database/migrations/${targetName}`).succeeded()
+    offset += 1
   }
 }


### PR DESCRIPTION
## Why

`@adonisjs/core@6` removed `command.publishMigrations`, leaving `configure.ts:33` calling a non-existent method. Symptoms:

- `tsc` reports `TS2339: Property 'publishMigrations' does not exist on type 'Configure'` (issue #34, error 1 of 70).
- At runtime, `node ace configure @escalated-dev/escalated-adonis` would crash before publishing any migrations — the package was effectively unusable for consumers.

## What

Inline the behavior of the old `publishMigrations` using `node:fs/promises`:

- Enumerate every `database/migrations/*.ts` shipped with the package.
- Copy each into the host app's `command.app.migrationsPath()` with a unique timestamp prefix (`Date.now() + i`) so the migrator runs them in the right order, after the host's own migrations.
- Skip files already published (suffix match on basename) unless `--force` is passed — makes re-runs idempotent.
- Log each copy with the canonical `logger.action(...).succeeded()` UX so output matches other Adonis configure flows.

This is **not** a \`@ts-ignore\`. It's a 1:1 functional replacement of the removed API; the same approach AdonisJS itself uses internally to copy stub files (just without the stub-templating layer, since these files don't need templating).

## Verification

- \`tsc --noEmit\` count: **70 → 69** errors (drops the configure.ts:33 entry; the other 69 are tracked under #34 sections 3-5).
- \`configure.ts\` alone now compiles cleanly:
  \`\`\`
  \$ ./node_modules/.bin/tsc --noEmit 2>&1 | grep configure.ts
  (no output)
  \`\`\`

Runtime verification (publishing migrations into a fresh adonis 6 host) is gated on the rest of the #34 work; no consumer can complete \`configure\` until all 69 errors clear. Will be e2e-verified in the final demo upgrade PR.

## Scope

One focused diff per PROMPT.md — only touches \`configure.ts\`. The remaining #34 sections (\`@adonisjs/transmit\` + \`adm-zip\` deps, cross-DB migration UUIDs, sso/ticket/mention service real-bug fixes, demo upgrade) ship as separate PRs.

Refs #34