### PR TITLE
fix(deps): add @adonisjs/transmit + adm-zip as optional peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,11 @@
         "@adonisjs/mail": "^9.0.0",
         "@adonisjs/prettier-config": "^1.4.5",
         "@adonisjs/session": "^7.6.0",
+        "@adonisjs/transmit": "^2.0.0",
         "@japa/runner": "^3.0.0",
+        "@types/adm-zip": "^0.5.5",
         "@types/luxon": "^3.7.1",
+        "adm-zip": "^0.5.0",
         "eslint": "^9.39.4",
         "prettier": "^3.8.1",
         "typescript": "^5.4.0"
@@ -37,7 +40,17 @@
         "@adonisjs/drive": "^3.0.0",
         "@adonisjs/inertia": "^1.0.0",
         "@adonisjs/lucid": "^21.0.0",
-        "@adonisjs/mail": "^9.0.0"
+        "@adonisjs/mail": "^9.0.0",
+        "@adonisjs/transmit": "^2.0.0",
+        "adm-zip": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@adonisjs/transmit": {
+          "optional": true
+        },
+        "adm-zip": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -773,6 +786,22 @@
         }
       }
     },
+    "node_modules/@adonisjs/transmit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adonisjs/transmit/-/transmit-2.0.2.tgz",
+      "integrity": "sha512-Oyh4S1773N1Ams9mmFM2pplLx8R0IdYwqSTBLRgeDWaR+cyWrL9ZQvF2q7GqIjNzZsXuDgMdPuLlNo+69zIZIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@boringnode/transmit": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "@adonisjs/core": "^6.2.0"
+      }
+    },
     "node_modules/@adonisjs/vite": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@adonisjs/vite/-/vite-3.0.0.tgz",
@@ -914,6 +943,45 @@
       },
       "bin": {
         "cuid2": "bin/cuid2.js"
+      }
+    },
+    "node_modules/@boringnode/transmit": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@boringnode/transmit/-/transmit-0.2.2.tgz",
+      "integrity": "sha512-xIBg5PKqqgawNsXffq1P+BpRDjplfwOspwcFH5wfSN6uVcd5hYGC9lJpcXa1oL3wkQZimtiJhrTHhZZtgh2lqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@boringnode/bus": "^0.7.0",
+        "@poppinss/utils": "^6.8.3",
+        "emittery": "^1.0.3",
+        "matchit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      }
+    },
+    "node_modules/@boringnode/transmit/node_modules/@boringnode/bus": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@boringnode/bus/-/bus-0.7.1.tgz",
+      "integrity": "sha512-F74H1XxpX0MSP2xfDv5cTuP9OgC4HHG+K2w8kNRj/k104D/aBMC7mcEcntgIZMX8QgcRQsREToP5kPH5kZOO/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "@poppinss/utils": "^6.9.2",
+        "object-hash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.6"
+      },
+      "peerDependencies": {
+        "ioredis": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        }
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
@@ -2599,6 +2667,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3056,6 +3134,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {
@@ -6140,6 +6228,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/matchit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/matchit/-/matchit-1.1.0.tgz",
+      "integrity": "sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@arr/every": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,17 @@
     "@adonisjs/drive": "^3.0.0",
     "@adonisjs/inertia": "^1.0.0",
     "@adonisjs/lucid": "^21.0.0",
-    "@adonisjs/mail": "^9.0.0"
+    "@adonisjs/mail": "^9.0.0",
+    "@adonisjs/transmit": "^2.0.0",
+    "adm-zip": "^0.5.0"
+  },
+  "peerDependenciesMeta": {
+    "@adonisjs/transmit": {
+      "optional": true
+    },
+    "adm-zip": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@adonisjs/auth": "^9.2.0",
@@ -73,8 +83,11 @@
     "@adonisjs/mail": "^9.0.0",
     "@adonisjs/prettier-config": "^1.4.5",
     "@adonisjs/session": "^7.6.0",
+    "@adonisjs/transmit": "^2.0.0",
     "@japa/runner": "^3.0.0",
+    "@types/adm-zip": "^0.5.5",
     "@types/luxon": "^3.7.1",
+    "adm-zip": "^0.5.0",
     "eslint": "^9.39.4",
     "prettier": "^3.8.1",
     "typescript": "^5.4.0"


### PR DESCRIPTION
## Why

Two TS2307 errors in #34 came from the package using these libraries through dynamic \`import()\` calls inside try/catch:

- \`src/bridge/native_context.ts:332\` — \`@adonisjs/transmit/services/main\` (real-time broadcast adapter; falls back to a \`console.warn\` if missing)
- \`src/services/plugin_service.ts:313\` — \`adm-zip\` (plugin ZIP extraction; only invoked when a host actually installs a plugin)

Without these in \`devDependencies\`, the package \`tsc --noEmit\` runs surface 2 unresolvable-module errors even though the runtime code already gracefully handles their absence.

## What

Production-correct expression of "optional at runtime, types at build":

- list both in \`peerDependencies\` + flag them in \`peerDependenciesMeta\` with \`optional: true\` so npm doesn't warn consumers who don't use them
- add to \`devDependencies\` (incl. \`@types/adm-zip\`) so the package type-checks here without forcing consumers

This is the canonical adonis idiom — same shape \`@adonisjs/auth\` uses to mark guards as optional based on configuration.

## Verification

\`tsc --noEmit\` count: **69 → 67** errors.

Confirmed neither module name appears in \`tsc\` output any more:
\`\`\`
\$ ./node_modules/.bin/tsc --noEmit 2>&1 | grep -E "transmit|adm-zip"
(no output)
\`\`\`

## Scope

One focused diff — only touches \`package.json\` + the resulting \`package-lock.json\`. The remaining 67 errors are tracked under #34 and ship as separate PRs (cross-DB migration UUIDs, sso/ticket/mention service real-bug fixes, demo upgrade).

Refs #34