### PR TITLE
fix(adonis-34): four real code bugs in services + routes

### DIFF
--- a/src/services/mention_service.ts
+++ b/src/services/mention_service.ts
@@ -108,12 +108,12 @@ export default class MentionService {
     for (const mention of mentions) {
       await TicketActivity.create({
         ticketId: ticket.id,
-        activityType: 'mention',
-        details: JSON.stringify({
+        type: 'mention',
+        properties: {
           mentioned_user_id: mention.user_id,
           reply_id: reply.id,
           message: `You were mentioned in ticket #${ticket.reference}`,
-        }),
+        },
       })
     }
   }

--- a/src/services/sso_service.ts
+++ b/src/services/sso_service.ts
@@ -175,7 +175,7 @@ export default class SsoService {
   private extractSamlAttributes(doc: Document): Record<string, string> {
     const attributes: Record<string, string> = {}
     const attrEls = doc.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Attribute')
-    for (const attrEl of attrEls) {
+    for (const attrEl of Array.from(attrEls)) {
       const name = attrEl.getAttribute('Name')
       if (!name) continue
       const valueEls = attrEl.getElementsByTagNameNS(

--- a/src/services/ticket_service.ts
+++ b/src/services/ticket_service.ts
@@ -457,7 +457,8 @@ export default class TicketService {
 
     return ticket.refresh()
   }
-  n /**
+
+  /**
    * Split a ticket by creating a new ticket from a specific reply.
    *
    * The new ticket inherits the original's priority, type, channel, department,

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type ActivityType =
   | 'reopened'
   | 'resolved'
   | 'closed'
+  | 'mention'
 
 /**
  * Inbound email statuses

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -255,6 +255,7 @@ function registerUiRoutes(config: any) {
           router
             .post('/tickets/:ticket/unsnooze', [AgentTicketsController, 'unsnooze'])
             .as('escalated.agent.tickets.unsnooze')
+          router
             .post('/tickets/:ticket/split', [AgentTicketsController, 'split'])
             .as('escalated.agent.tickets.split')
         })


### PR DESCRIPTION
## Why

Section 4 of #34. Each item below was masking a real product defect, not just a TypeScript complaint:

1. **\`sso_service.ts:178\`** — \`for (const x of HTMLCollection)\` (TS2488: \`HTMLCollectionOf<Element>\` has no \`Symbol.iterator\`). Beyond the compile error, this would also fail at runtime in non-DOM contexts (the SAML-assertion parsing path). SAML SSO logins were broken.

2. **\`mention_service.ts:111\`** — was passing \`activityType\` and \`details\` keys, but \`TicketActivity\` declares \`type\` and \`properties\`. Mention activities **never persisted** before this fix; the call would have thrown at runtime as soon as anyone @-mentioned someone in a reply.

3. **\`ticket_service.ts:460\`** — stray \`n\` token before the \`/** Split a ticket */\` block. Looks like a partial keystroke from an aborted edit. The file barely parsed as a class body.

4. **\`start/routes.ts:258\`** — \`split\` route was chained off the \`unsnooze\` route's \`.as()\`, which returns the route object (no \`.post\`). The route was unreachable; \`POST /tickets/:ticket/split\` was never registered.

## What

1. \`Array.from(attrEls)\` so iteration goes through the spec-mandated indexed-getter path.
2. Renamed properties to \`type\` / \`properties\`, and added \`'mention'\` to the \`ActivityType\` union (it's a valid product activity, just not previously listed).
3. Removed the stray \`n\`.
4. Split the \`unsnooze\` and \`split\` registrations into two \`router.post(...).as(...)\` blocks matching the rest of the file.

## Verification

\`tsc --noEmit\` count: **67 → 63** errors. All four target sites are clean:
\`\`\`
\$ ./node_modules/.bin/tsc --noEmit 2>&1 | grep -E "sso_service|ticket_service|mention_service|start/routes"
(no output)
\`\`\`

ESLint clean on all five touched files.

Refs #34