### PR TITLE
fix(migrations): cross-DB UUID for import_jobs (drop sqlite-only default)

### DIFF
--- a/database/migrations/0019_create_escalated_import_jobs.ts
+++ b/database/migrations/0019_create_escalated_import_jobs.ts
@@ -5,15 +5,12 @@ export default class CreateEscalatedImportJobs extends BaseSchema {
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
-      // UUID primary key
-      table
-        .uuid('id')
-        .primary()
-        .defaultTo(
-          this.raw(
-            "(lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab',abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6))))"
-          )
-        )
+      // UUID primary key — generated app-side via `crypto.randomUUID()`
+      // in ImportJob's `beforeCreate` hook. App-level generation keeps
+      // the migration portable across sqlite, postgres, and mysql; each
+      // dialect needs a different DB-side default (`gen_random_uuid()`,
+      // `(UUID())`, sqlite has nothing native), so we don't pick one.
+      table.uuid('id').primary()
 
       // Platform slug (e.g. "zendesk", "freshdesk", "intercom")
       table.string('platform').notNullable()

--- a/src/models/import_job.ts
+++ b/src/models/import_job.ts
@@ -10,9 +10,9 @@
 */
 
 import { type DateTime } from 'luxon'
-import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
+import { BaseModel, beforeCreate, column, hasMany } from '@adonisjs/lucid/orm'
 import type { HasMany } from '@adonisjs/lucid/types/relations'
-import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'node:crypto'
+import { createCipheriv, createDecipheriv, randomBytes, randomUUID, createHash } from 'node:crypto'
 import ImportSourceMap from './import_source_map.js'
 
 // --------------------------------------------------------------------------
@@ -145,6 +145,15 @@ export default class ImportJob extends BaseModel {
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
+
+  // ---- Hooks ----
+
+  @beforeCreate()
+  static assignUuid(job: ImportJob) {
+    if (!job.id) {
+      job.id = randomUUID()
+    }
+  }
 
   // ---- Relationships ----
 


### PR DESCRIPTION
## Why

The \`escalated_import_jobs\` migration used a sqlite-specific raw expression as the DB-side default for the \`id\` column:

\`\`\`ts
.defaultTo(this.raw(
  "(lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || ..."
))
\`\`\`

\`randomblob\` is **sqlite-only** — anyone running this migration against postgres or mysql (the supported production DBs per the docker compose stacks) would hit a SQL error before the table was created. The package was effectively unusable for production hosts.

Section 5 of #34.

## What

App-level UUID generation. Each dialect needs a different DB-side default:

- postgres: \`gen_random_uuid()\` (requires pgcrypto extension)
- mysql 8+: \`(UUID())\`
- sqlite: nothing native

Picking one breaks the others. So generate via \`crypto.randomUUID()\` in a Lucid \`@beforeCreate\` hook on the model — portable across all three dialects, no DB-side dependency.

### Migration

Drop the \`defaultTo(...)\` and document the reason.

### Model

Add a \`@beforeCreate\` hook \`assignUuid\` that sets \`job.id = randomUUID()\` if not already set. The conditional allows callers to pass an explicit id (e.g. for tests), defaulting to a fresh v4 otherwise.

## Verification

- \`tsc --noEmit\` count unchanged at **63** (this fix is for runtime portability, not a TS error reduction — the original raw SQL was a string).
- \`eslint\` clean on both touched files.

## Scope

One focused diff. Other Section 6 work (demo upgrade) ships separately. The remaining 63 tsc errors are cascading Lucid model errors (TS2339 ×36, TS2769 ×16, TS18046 ×6) tracked under #34.

Refs #34