### PR TITLE
fix(types): augment ContainerBindings for escalated.* singletons

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,10 @@
 // the package is type-checked standalone.
 import './src/types/augmentations.js'
 
+// Augment ContainerBindings so `container.singleton('escalated.*', ...)` and
+// `container.make('escalated.*')` type-check against the right resolved type.
+import './src/types/container_bindings.js'
+
 export { configure } from './configure.js'
 export { default as EscalatedProvider } from './providers/escalated_provider.js'
 

--- a/src/types/container_bindings.ts
+++ b/src/types/container_bindings.ts
@@ -1,0 +1,52 @@
+/*
+|--------------------------------------------------------------------------
+| Container bindings augmentation
+|--------------------------------------------------------------------------
+|
+| The provider registers each escalated singleton against a string key
+| (e.g. `'escalated.ticketService'`). AdonisJS 6 requires those keys to
+| be declared on `ContainerBindings` so `container.make(key)` returns the
+| right type and `container.singleton(key, ...)` accepts the resolver.
+|
+| This file is loaded for its side effects in `index.ts`, the same way
+| `augmentations.ts` pulls in the host middleware augmentations.
+|
+*/
+
+import type HookManager from '../support/hook_manager.js'
+import type PluginUIService from '../services/plugin_ui_service.js'
+import type PluginService from '../services/plugin_service.js'
+import type PluginBridge from '../bridge/plugin_bridge.js'
+import type TicketService from '../services/ticket_service.js'
+import type AssignmentService from '../services/assignment_service.js'
+import type SlaService from '../services/sla_service.js'
+import type EscalationService from '../services/escalation_service.js'
+import type MacroService from '../services/macro_service.js'
+import type NotificationService from '../services/notification_service.js'
+import type AttachmentService from '../services/attachment_service.js'
+import type InboundEmailService from '../services/inbound_email_service.js'
+import type ImportService from '../services/import_service.js'
+import type ChatSessionService from '../services/chat_session_service.js'
+import type ChatRoutingService from '../services/chat_routing_service.js'
+import type ChatAvailabilityService from '../services/chat_availability_service.js'
+
+declare module '@adonisjs/core/types' {
+  interface ContainerBindings {
+    'escalated.hookManager': HookManager
+    'escalated.pluginUIService': PluginUIService
+    'escalated.pluginService': PluginService
+    'escalated.pluginBridge': PluginBridge
+    'escalated.ticketService': TicketService
+    'escalated.assignmentService': AssignmentService
+    'escalated.slaService': SlaService
+    'escalated.escalationService': EscalationService
+    'escalated.macroService': MacroService
+    'escalated.notificationService': NotificationService
+    'escalated.attachmentService': AttachmentService
+    'escalated.inboundEmailService': InboundEmailService
+    'escalated.importService': ImportService
+    'escalated.chatSessionService': ChatSessionService
+    'escalated.chatRoutingService': ChatRoutingService
+    'escalated.chatAvailabilityService': ChatAvailabilityService
+  }
+}


### PR DESCRIPTION
## Why

The provider registers 16 services against string keys (e.g. \`'escalated.ticketService'\`), but AdonisJS 6 requires those keys to be declared on \`ContainerBindings\` so:

- \`container.singleton(key, ...)\` accepts the resolver
- \`container.make(key)\` returns the right resolved type

Without the augmentation, every binding triggered \`TS2769\` ("No overload matches this call") and every consumer (\`container.make\`) would have inferred \`unknown\` for the resolved service.

## What

Add \`src/types/container_bindings.ts\` declaring the augmentation, and side-effect-import it from \`index.ts\` next to the existing \`augmentations.ts\` middleware-augmentation import. Same pattern, parallel structure.

## Verification

\`tsc --noEmit\` count: **63 → 45** errors (cuts all 16 \`TS2769\` from the provider plus 2 cascading errors).

ESLint clean on both touched files.

## Scope

One focused diff. Remaining 45 errors are TS2339 ×34 (Lucid model property/relation access — needs targeted fixes), TS18046 ×6, plus a few stragglers — tracked under #34. The Section 6 demo upgrade follows once the package compiles.

Refs #34