### PR TITLE
fix(auth): typed auth.user helper for controllers

### DIFF
--- a/src/controllers/admin_canned_responses_controller.ts
+++ b/src/controllers/admin_canned_responses_controller.ts
@@ -2,6 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import CannedResponse from '../models/canned_response.js'
 import { getRenderer } from '../rendering/renderer.js'
 import { t } from '../support/i18n.js'
+import { requireAuthUser } from '../support/auth_user.js'
 
 export default class AdminCannedResponsesController {
   async index(ctx: HttpContext) {
@@ -17,7 +18,7 @@ export default class AdminCannedResponsesController {
       body: data.body,
       category: data.category || null,
       isShared: data.is_shared !== false,
-      createdBy: auth.user!.id,
+      createdBy: requireAuthUser(auth).id,
     })
 
     session.flash('success', t('admin.canned_response_created'))

--- a/src/controllers/admin_macros_controller.ts
+++ b/src/controllers/admin_macros_controller.ts
@@ -2,6 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import Macro from '../models/macro.js'
 import { getRenderer } from '../rendering/renderer.js'
 import { t } from '../support/i18n.js'
+import { requireAuthUser } from '../support/auth_user.js'
 
 export default class AdminMacrosController {
   async index(ctx: HttpContext) {
@@ -18,7 +19,7 @@ export default class AdminMacrosController {
       actions: data.actions,
       isShared: data.is_shared !== false,
       order: data.order || 0,
-      createdBy: auth.user!.id,
+      createdBy: requireAuthUser(auth).id,
     })
 
     session.flash('success', t('admin.macro_created'))

--- a/src/controllers/admin_tickets_controller.ts
+++ b/src/controllers/admin_tickets_controller.ts
@@ -12,6 +12,7 @@ import MacroService from '../services/macro_service.js'
 import { getRenderer } from '../rendering/renderer.js'
 import type { TicketStatus, TicketPriority } from '../types.js'
 import { t } from '../support/i18n.js'
+import { requireAuthUser } from '../support/auth_user.js'
 
 export default class AdminTicketsController {
   protected ticketService = new TicketService()
@@ -63,7 +64,7 @@ export default class AdminTicketsController {
    */
   async show(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
 
     await ticket.load('department')
     await ticket.load('tags')
@@ -222,7 +223,7 @@ export default class AdminTicketsController {
 
   async applyMacro(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const { macro_id: macroId } = ctx.request.only(['macro_id'])
     const macro = await Macro.query()
       .withScopes((scopes) => scopes.forAgent(user.id))
@@ -236,7 +237,7 @@ export default class AdminTicketsController {
 
   async follow(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
     if (await ticket.isFollowedBy(userId)) {
       await ticket.unfollow(userId)
       ctx.session.flash('success', t('ticket.unfollowed'))
@@ -249,8 +250,9 @@ export default class AdminTicketsController {
 
   async presence(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const userId = ctx.auth.user!.id
-    const userName = (ctx.auth.user as any).name ?? 'Admin'
+    const user = requireAuthUser(ctx.auth)
+    const userId = user.id
+    const userName = (user as any).name ?? 'Admin'
     const presenceStore = (globalThis as any).__escalated_presence ?? {}
     const ticketKey = `ticket_${ticket.id}`
     if (!presenceStore[ticketKey]) presenceStore[ticketKey] = {}

--- a/src/controllers/agent_dashboard_controller.ts
+++ b/src/controllers/agent_dashboard_controller.ts
@@ -2,14 +2,14 @@ import { DateTime } from 'luxon'
 import type { HttpContext } from '@adonisjs/core/http'
 import Ticket from '../models/ticket.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { requireAuthUser } from '../support/auth_user.js'
 
 export default class AgentDashboardController {
   /**
    * GET /support/agent — Agent dashboard
    */
   async handle(ctx: HttpContext) {
-    const { auth } = ctx
-    const userId = auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
     const startOfDay = DateTime.now().startOf('day').toSQL()!
     const startOfWeek = DateTime.now().startOf('week').toSQL()!
 

--- a/src/controllers/agent_mentions_controller.ts
+++ b/src/controllers/agent_mentions_controller.ts
@@ -1,9 +1,10 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import MentionService from '../services/mention_service.js'
+import { getAuthUser } from '../support/auth_user.js'
 
 export default class AgentMentionsController {
   async index(ctx: HttpContext) {
-    const userId = ctx.auth?.user?.id
+    const userId = getAuthUser(ctx.auth)?.id
     if (!userId) return ctx.response.unauthorized({ error: 'Unauthorized' })
     const service = new MentionService()
     const mentions = await service.unreadMentions(userId)
@@ -11,7 +12,7 @@ export default class AgentMentionsController {
   }
 
   async markRead(ctx: HttpContext) {
-    const userId = ctx.auth?.user?.id
+    const userId = getAuthUser(ctx.auth)?.id
     if (!userId) return ctx.response.unauthorized({ error: 'Unauthorized' })
     const mentionIds = ctx.request.input('mention_ids', [])
     const service = new MentionService()

--- a/src/controllers/agent_tickets_controller.ts
+++ b/src/controllers/agent_tickets_controller.ts
@@ -12,6 +12,7 @@ import MacroService from '../services/macro_service.js'
 import { getRenderer } from '../rendering/renderer.js'
 import type { TicketStatus, TicketPriority } from '../types.js'
 import { t } from '../support/i18n.js'
+import { requireAuthUser } from '../support/auth_user.js'
 
 export default class AgentTicketsController {
   protected ticketService = new TicketService()
@@ -61,7 +62,7 @@ export default class AgentTicketsController {
    */
   async show(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
 
     await ticket.load('department')
     await ticket.load('tags')
@@ -269,7 +270,7 @@ export default class AgentTicketsController {
    */
   async applyMacro(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const { macro_id: macroId } = ctx.request.only(['macro_id'])
 
     const macro = await Macro.query()
@@ -289,7 +290,7 @@ export default class AgentTicketsController {
    */
   async follow(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
 
     if (await ticket.isFollowedBy(userId)) {
       await ticket.unfollow(userId)
@@ -307,8 +308,9 @@ export default class AgentTicketsController {
    */
   async presence(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const userId = ctx.auth.user!.id
-    const userName = (ctx.auth.user as any).name ?? (ctx.auth.user as any).fullName ?? 'Agent'
+    const user = requireAuthUser(ctx.auth)
+    const userId = user.id
+    const userName = (user as any).name ?? (user as any).fullName ?? 'Agent'
 
     // Use a simple in-memory store (in production, use Redis/cache)
     const presenceStore = (globalThis as any).__escalated_presence ?? {}

--- a/src/controllers/chat_controller.ts
+++ b/src/controllers/chat_controller.ts
@@ -3,6 +3,7 @@ import ChatSessionService from '../services/chat_session_service.js'
 import type ChatSession from '../models/chat_session.js'
 import AgentProfile from '../models/agent_profile.js'
 import { DateTime } from 'luxon'
+import { requireAuthUser } from '../support/auth_user.js'
 
 /**
  * Agent-facing chat controller.
@@ -16,7 +17,7 @@ export default class ChatController {
    * GET /agent/chats — List active chats for the authenticated agent.
    */
   async index(ctx: HttpContext) {
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const chats = await this.chatService.getAgentChats(user.id)
 
     return ctx.response.json({
@@ -40,7 +41,7 @@ export default class ChatController {
    * POST /agent/chats/:id/accept — Accept a chat from the queue.
    */
   async accept(ctx: HttpContext) {
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const sessionId = ctx.params.id
 
     const session = await this.chatService.assignAgent(sessionId, user.id)
@@ -54,7 +55,7 @@ export default class ChatController {
    * POST /agent/chats/:id/end — End a chat session.
    */
   async end(ctx: HttpContext) {
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const sessionId = ctx.params.id
 
     const session = await this.chatService.endChat(sessionId, user)
@@ -68,7 +69,7 @@ export default class ChatController {
    * POST /agent/chats/:id/transfer — Transfer a chat to another agent.
    */
   async transfer(ctx: HttpContext) {
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const sessionId = ctx.params.id
     const { agent_id: newAgentId } = ctx.request.only(['agent_id'])
 
@@ -87,7 +88,7 @@ export default class ChatController {
    * POST /agent/chats/status — Update the agent's chat availability status.
    */
   async updateStatus(ctx: HttpContext) {
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const { status } = ctx.request.only(['status'])
 
     if (!['online', 'away', 'offline'].includes(status)) {
@@ -117,7 +118,7 @@ export default class ChatController {
    * POST /agent/chats/:id/message — Send a message in a chat.
    */
   async message(ctx: HttpContext) {
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const sessionId = ctx.params.id
     const { body } = ctx.request.only(['body'])
 
@@ -146,7 +147,7 @@ export default class ChatController {
    * POST /agent/chats/:id/typing — Send a typing indicator.
    */
   async typing(ctx: HttpContext) {
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const sessionId = ctx.params.id
     const { is_typing: isTyping } = ctx.request.only(['is_typing'])
 

--- a/src/controllers/satisfaction_rating_controller.ts
+++ b/src/controllers/satisfaction_rating_controller.ts
@@ -2,6 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import Ticket from '../models/ticket.js'
 import SatisfactionRating from '../models/satisfaction_rating.js'
 import { t } from '../support/i18n.js'
+import { requireAuthUser } from '../support/auth_user.js'
 
 export default class SatisfactionRatingController {
   /**
@@ -9,7 +10,7 @@ export default class SatisfactionRatingController {
    */
   async store(ctx: HttpContext) {
     const ticket = (ctx as any).escalatedTicket as Ticket
-    const user = ctx.auth.user!
+    const user = requireAuthUser(ctx.auth)
     const { rating, comment } = ctx.request.only(['rating', 'comment'])
 
     if (!['resolved', 'closed'].includes(ticket.status)) {

--- a/src/controllers/saved_views_controller.ts
+++ b/src/controllers/saved_views_controller.ts
@@ -1,13 +1,14 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import SavedView from '../models/saved_view.js'
 import { t } from '../support/i18n.js'
+import { requireAuthUser } from '../support/auth_user.js'
 
 export default class SavedViewsController {
   /**
    * GET /support/agent/views — List saved views for the current user
    */
   async index(ctx: HttpContext) {
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
 
     const views = await SavedView.query()
       .withScopes((scopes) => scopes.visibleTo(userId))
@@ -21,7 +22,7 @@ export default class SavedViewsController {
    * POST /support/agent/views — Create a new saved view
    */
   async store(ctx: HttpContext) {
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
     const data = ctx.request.only([
       'name',
       'filters',
@@ -57,7 +58,7 @@ export default class SavedViewsController {
    * PUT /support/agent/views/:id — Update a saved view
    */
   async update(ctx: HttpContext) {
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
     const viewId = ctx.params.id
 
     const view = await SavedView.query()
@@ -99,7 +100,7 @@ export default class SavedViewsController {
    * DELETE /support/agent/views/:id — Delete a saved view
    */
   async destroy(ctx: HttpContext) {
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
     const viewId = ctx.params.id
 
     const view = await SavedView.query().where('id', viewId).where('user_id', userId).firstOrFail()
@@ -113,7 +114,7 @@ export default class SavedViewsController {
    * POST /support/agent/views/reorder — Reorder saved views
    */
   async reorder(ctx: HttpContext) {
-    const userId = ctx.auth.user!.id
+    const userId = requireAuthUser(ctx.auth).id
     const { order } = ctx.request.only(['order'])
 
     if (!Array.isArray(order)) {

--- a/src/support/auth_user.ts
+++ b/src/support/auth_user.ts
@@ -1,0 +1,60 @@
+/*
+|--------------------------------------------------------------------------
+| Typed auth.user accessors
+|--------------------------------------------------------------------------
+|
+| `HttpContext['auth'].user` is typed as `never` when the package is built
+| standalone, because AdonisJS's `Authenticators` interface is empty until
+| the host app's auth config augments it. We can't ship our own
+| `Authenticators` augmentation without conflicting with whatever guard
+| the host configures.
+|
+| So instead, controllers/services that need the user go through these
+| helpers, which assert the minimum shape the package actually relies on
+| (`{ id, constructor }`). Hosts whose user has more fields satisfy this
+| contract trivially; hosts whose user model lacks `id` would be a misuse
+| we'd surface at runtime.
+|
+*/
+
+import type { HttpContext } from '@adonisjs/core/http'
+
+/**
+ * Minimum shape the package needs from the host's authenticated user.
+ *
+ * - `id`: used as a foreign key on causer/assigner/etc. associations.
+ *   The escalated schema uses numeric primary keys, so `id` must be a
+ *   `number` here even though some hosts use string ids elsewhere — they
+ *   should expose a numeric `id` on the user model for compatibility.
+ * - `constructor.name`: used to populate the polymorphic `causer_type`
+ *   column on `escalated_ticket_activities` and similar audit rows.
+ */
+export interface EscalatedAuthUser {
+  id: number
+  constructor: { name: string }
+}
+
+type AuthLike = HttpContext['auth'] | { user?: unknown }
+
+/**
+ * Return the currently authenticated user, or `null` if anonymous.
+ */
+export function getAuthUser(auth: AuthLike): EscalatedAuthUser | null {
+  const user = (auth as { user?: EscalatedAuthUser }).user
+  return user ?? null
+}
+
+/**
+ * Return the currently authenticated user, throwing if anonymous.
+ *
+ * Use in admin/agent controllers that are mounted behind `auth` middleware
+ * — the throw is just defense-in-depth; the middleware should already
+ * have rejected the request.
+ */
+export function requireAuthUser(auth: AuthLike): EscalatedAuthUser {
+  const user = getAuthUser(auth)
+  if (!user) {
+    throw new Error('Authentication required')
+  }
+  return user
+}


### PR DESCRIPTION
## Why

\`HttpContext['auth'].user\` is typed as \`never\` when the package is built standalone, because AdonisJS's \`Authenticators\` interface is empty until the host app's auth config augments it. The package can't ship its own \`Authenticators\` augmentation without conflicting with whatever guard the host configures.

This caused **27 \`TS2339\` errors** of the form \`Property 'id' does not exist on type 'never'\` across nine controllers — every site that called \`auth.user!.id\` to assign a foreign key.

## What

Add a typed accessor in \`src/support/auth_user.ts\`:

- \`EscalatedAuthUser\` declares the minimum shape the package actually needs from the host's user model — \`id: number\` + \`constructor.name\` (used as the polymorphic \`causer_type\` on activity rows).
- \`getAuthUser(auth)\` returns \`EscalatedAuthUser | null\`.
- \`requireAuthUser(auth)\` returns \`EscalatedAuthUser\`, throws on anonymous (defense-in-depth; the \`auth\` middleware should have rejected the request before reaching the controller).

Replaced \`auth.user!.id\` and \`auth.user!\` with \`requireAuthUser(auth).id\` / \`requireAuthUser(auth)\` across:

- \`admin_canned_responses_controller\`
- \`admin_macros_controller\`
- \`admin_tickets_controller\`
- \`agent_dashboard_controller\`
- \`agent_mentions_controller\` (used \`getAuthUser\` to preserve the original anonymous-passthrough behavior)
- \`agent_tickets_controller\`
- \`chat_controller\`
- \`satisfaction_rating_controller\`
- \`saved_views_controller\`

## Verification

\`tsc --noEmit\` count: **45 → 18** errors (cuts all 27 auth.user-related errors).

ESLint clean across all 10 touched files.

## Scope

One focused diff. Remaining 18 errors are truly heterogeneous: real bugs (\`pluck\`/\`onConflict\` API misuses, missing helpers.string import, undefined \`result\` symbol, \`'live'\` not in TicketStatus union, etc.) that each need targeted fixes. Tracked under #34.

Refs #34