### PR TITLE
feat(demo): full e2e — picker + click-login + agent profile page

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,37 @@
 # syntax=docker/dockerfile:1.7
 #
-# Adonis demo (placeholder pattern, matching dotnet/spring/phoenix demos).
+# Adonis demo (full e2e: picker + click-login + agent profile page).
 #
-# Bootstraps an AdonisJS Inertia starter non-interactively, then overlays a
-# tiny /demo route. The escalated-adonis package is intentionally NOT
-# installed here because of a tracked package-source issue
-# (https://github.com/escalated-dev/escalated-adonis/issues/34) — the
-# package's TypeScript build produces 314 errors and the configure.ts
-# calls publishMigrations which @adonisjs/core@6 no longer exports. Once
-# #34 lands, layering the package back in is a small follow-up.
+# Bootstraps an AdonisJS Inertia starter non-interactively, installs
+# escalated-adonis from the local checkout, runs `node ace configure` to
+# publish the migrations, runs them against postgres, then overlays a
+# /demo controller (picker + login + agent page) that proves the
+# package's models and schema work end-to-end. Mirrors the pattern shipped
+# in dotnet #16, spring #18, and phoenix #28.
 
 FROM node:22-alpine AS host
 
 RUN apk add --no-cache git
 
-WORKDIR /host
+# 1) Build a minimal tarball of the escalated-adonis package so we can
+#    `npm install` it from disk without copying the whole repo into the
+#    host's node_modules tree (avoids the symlink-circular-dep pitfall
+#    when the source tree is itself the host).
+WORKDIR /pkg
+COPY package.json package-lock.json tsconfig.json index.ts configure.ts ./
+COPY src/ ./src/
+COPY providers/ ./providers/
+COPY stubs/ ./stubs/
+COPY database/ ./database/
+COPY start/ ./start/
+COPY scripts/ ./scripts/
+RUN mkdir -p /pkg-out && \
+    npm ci --silent && \
+    npm run build && \
+    npm pack --pack-destination=/pkg-out
 
-# create-adonisjs is non-interactive when given --kit + --adapter + --no-ssr.
-# --no-git skips git init; we don't need a repo inside the demo container.
-# Use the slim API kit (no Vite/Inertia/SSR setup) — the placeholder demo
-# only serves static HTML, so we keep the host minimal until #34 is fixed.
+# 2) Bootstrap the AdonisJS host.
+WORKDIR /host
 RUN npm install -g create-adonisjs --silent && \
     create-adonisjs \
         --kit=api \
@@ -29,13 +41,30 @@ RUN npm install -g create-adonisjs --silent && \
         --git-init=false \
         .
 
-# Overlay the /demo placeholder route + controller.
-COPY docker/host-app/demo_routes.ts /host/start/demo_routes.ts
-COPY docker/host-app/demo_controller.ts /host/app/controllers/demo_controller.ts
+# 3) Install the escalated-adonis tarball + its peer/optional deps that
+#    the host will actually exercise (lucid is already in --kit=api;
+#    add the rest the package declares as peers).
+RUN cp /pkg-out/escalated-dev-escalated-adonis-*.tgz /host/escalated-adonis.tgz && \
+    npm install --no-audit --no-fund --legacy-peer-deps \
+        ./escalated-adonis.tgz \
+        @adonisjs/auth@^9 \
+        @adonisjs/cache@^1 \
+        @adonisjs/drive@^3 \
+        @adonisjs/inertia@^1 \
+        @adonisjs/mail@^9 \
+        luxon
 
-# Wire the demo route file into start/routes.ts (idempotent).
-RUN grep -q "demo_routes" /host/start/routes.ts || \
-    echo "import './demo_routes.js'" >> /host/start/routes.ts
+# 4) Configure the package — publishes config + migrations into the host.
+#    --force overwrites any existing escalated config (this is a fresh
+#    bootstrap, but the flag also picks up the stub re-publish path).
+RUN node ace.js configure @escalated-dev/escalated-adonis --force
+
+# 5) Overlay the demo controller + routes (seed runs lazily on first
+#    /demo request — see seedIfEmpty in demo_controller.ts).
+#    REPLACE the default scaffold's start/routes.ts so its `GET /` doesn't
+#    collide with the demo's redirect-to-/demo handler.
+COPY docker/host-app/demo_controller.ts /host/app/controllers/demo_controller.ts
+COPY docker/host-app/demo_routes.ts /host/start/routes.ts
 
 FROM node:22-alpine AS runtime
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,7 @@ until pg_isready -h "${DB_HOST:-db}" -p "${DB_PORT:-5432}" -U "${DB_USER:-escala
 done
 
 echo "[demo] running migrations"
-node ace.js migration:run --force 2>&1 || echo "[demo] migrations: skipped/failed"
+node ace.js migration:run --force
 
-echo "[demo] ready"
+echo "[demo] ready (agents will be seeded on first /demo request)"
 exec "$@"

--- a/docker/host-app/demo_controller.ts
+++ b/docker/host-app/demo_controller.ts
@@ -1,16 +1,152 @@
 import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import AgentProfile from '@escalated-dev/escalated-adonis/models/agent_profile'
+import Department from '@escalated-dev/escalated-adonis/models/department'
+
+const AGENTS: Array<{ userId: number; label: string; chatStatus: string }> = [
+  { userId: 1, label: 'Alice (Admin)', chatStatus: 'available' },
+  { userId: 2, label: 'Bob (Agent)', chatStatus: 'available' },
+  { userId: 3, label: 'Carol (Agent)', chatStatus: 'busy' },
+]
+
+const DEPARTMENTS = [
+  { name: 'Support', slug: 'support' },
+  { name: 'Billing', slug: 'billing' },
+]
+
+const LABELS_BY_USER = new Map(AGENTS.map((a) => [a.userId, a.label]))
+
+let seeded = false
+
+async function seedIfEmpty() {
+  if (seeded) return
+  const count = await AgentProfile.query().count('* as total').first()
+  const total = (count as any)?.$extras?.total ?? (count as any)?.total ?? 0
+  if (Number(total) > 0) {
+    seeded = true
+    return
+  }
+  const now = DateTime.now()
+  for (const dep of DEPARTMENTS) {
+    await Department.firstOrCreate(
+      { slug: dep.slug },
+      { name: dep.name, isActive: true, createdAt: now, updatedAt: now } as any
+    )
+  }
+  for (const a of AGENTS) {
+    await AgentProfile.create({
+      userId: a.userId,
+      chatStatus: a.chatStatus,
+      maxConcurrentChats: 5,
+      createdAt: now,
+      updatedAt: now,
+    } as any)
+  }
+  seeded = true
+}
 
 export default class DemoController {
-  async index({ response }: HttpContext) {
-    return response.type('text/html').send(`
-      <html><body><h1>Escalated Adonis Demo</h1>
-      <p>Host project bootstrapped (AdonisJS 6 + Inertia + Postgres). The
-      escalated-adonis package is intentionally not installed in this
-      container while
-      <a href="https://github.com/escalated-dev/escalated-adonis/issues/34">#34</a>
-      is fixed upstream — see PR body. Once the package builds cleanly,
-      adding the path-dep + click-login picker is a small follow-up.</p>
-      </body></html>
-    `)
+  /**
+   * GET / → /demo
+   */
+  async root({ response }: HttpContext) {
+    return response.redirect('/demo')
   }
+
+  /**
+   * GET /demo — picker listing seeded agent profiles.
+   */
+  async picker({ response }: HttpContext) {
+    await seedIfEmpty()
+    const agents = await AgentProfile.query().orderBy('id', 'asc')
+    const rows = agents
+      .map((a) => {
+        const userId = (a as any).userId
+        const chatStatus = (a as any).chatStatus ?? 'offline'
+        const label = LABELS_BY_USER.get(userId) ?? `Agent ${a.id}`
+        return `
+          <form method="POST" action="/demo/login/${a.id}">
+            <button type="submit" class="user">
+              <span>${escape(label)}</span>
+              <span class="meta">UserId ${userId} · chat: ${escape(chatStatus)}</span>
+            </button>
+          </form>`
+      })
+      .join('')
+    return response.type('text/html').send(html('Escalated · AdonisJS Demo', `
+      <h1>Escalated AdonisJS Demo</h1>
+      <p class="lede">Click an agent to load their profile. Database seeds on first boot.</p>
+      ${rows || '<p class="meta">No agents seeded yet.</p>'}
+    `))
+  }
+
+  /**
+   * POST /demo/login/:id — "log in" as the chosen agent.
+   *
+   * The full host's auth integration would set a session cookie here. For
+   * the demo we just redirect to the agent profile page, which proves the
+   * package's data is reachable from a normal AdonisJS controller — the
+   * same pattern dotnet/spring/phoenix demos use.
+   */
+  async login({ params, response }: HttpContext) {
+    // 303 See Other forces the client to switch the redirected request to
+    // GET, even when the original request was POST (default 302 keeps the
+    // original method, which would land at "POST /demo/agent/:id" → 404).
+    return response.status(303).header('Location', `/demo/agent/${params.id}`).send('')
+  }
+
+  /**
+   * GET /demo/agent/:id — show the agent's profile + a few counts to
+   * prove migrations + seeded data + Lucid model resolution all work
+   * end-to-end against Postgres.
+   */
+  async agentPage({ params, response }: HttpContext) {
+    const agent = await AgentProfile.find(params.id)
+    if (!agent) {
+      return response.status(404).type('text/html').send(html('Agent not found', `
+        <h1>Agent not found</h1>
+        <p><a href="/demo">Back to picker</a></p>
+      `))
+    }
+    const departmentCount = (await Department.query().count('* as total').first()) as any
+    const total = departmentCount?.$extras?.total ?? departmentCount?.total ?? 0
+    const userId = (agent as any).userId
+    const chatStatus = (agent as any).chatStatus ?? 'offline'
+    const maxChats = (agent as any).maxConcurrentChats ?? '—'
+    const label = LABELS_BY_USER.get(userId) ?? `Agent ${agent.id}`
+    return response.type('text/html').send(html(`Agent ${label}`, `
+      <h1>Logged in as ${escape(label)}</h1>
+      <p class="meta">UserId: ${userId} · Chat status: ${escape(chatStatus)} · Max concurrent chats: ${maxChats}</p>
+      <p>AdonisJS 6 host + Postgres + Lucid round-trip verified end-to-end.
+      Department count: ${total}. Click <a href="/demo">back to picker</a>.</p>
+    `))
+  }
+}
+
+function escape(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function html(title: string, body: string): string {
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<title>${escape(title)}</title>
+<style>
+  body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0f172a;color:#e2e8f0;margin:0;padding:2rem}
+  .wrap{max-width:720px;margin:0 auto}
+  h1{font-size:1.5rem;margin:0 0 .25rem}
+  p.lede{color:#94a3b8;margin:0 0 2rem}
+  p.meta{color:#94a3b8;font-size:.85rem;margin-bottom:1rem}
+  form{display:block;margin:0}
+  button.user{display:flex;width:100%;align-items:center;justify-content:space-between;padding:.75rem 1rem;background:#1e293b;border:1px solid #334155;border-radius:8px;color:#f1f5f9;font-size:.95rem;cursor:pointer;margin-bottom:.5rem;text-align:left}
+  button.user:hover{background:#273549;border-color:#475569}
+  .meta{color:#94a3b8;font-size:.8rem}
+  a{color:#60a5fa}
+</style></head><body><div class="wrap">
+${body}
+</div></body></html>`
 }

--- a/docker/host-app/demo_routes.ts
+++ b/docker/host-app/demo_routes.ts
@@ -2,4 +2,7 @@ import router from '@adonisjs/core/services/router'
 
 const DemoController = () => import('#controllers/demo_controller')
 
-router.get('/demo', [DemoController, 'index'])
+router.get('/', [DemoController, 'root'])
+router.get('/demo', [DemoController, 'picker'])
+router.post('/demo/login/:id', [DemoController, 'login'])
+router.get('/demo/agent/:id', [DemoController, 'agentPage'])

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "start"
   ],
   "scripts": {
-    "build": "tsc",
-    "build:emit": "tsc --noEmitOnError false || true",
+    "build": "tsc && npm run copy:stubs",
+    "build:emit": "tsc --noEmitOnError false || true && npm run copy:stubs",
+    "copy:stubs": "node ./scripts/copy-build-assets.mjs",
     "dev": "tsc --watch",
     "clean": "rm -rf build",
     "test": "node --test tests/*.test.js",

--- a/providers/escalated_provider.ts
+++ b/providers/escalated_provider.ts
@@ -132,9 +132,6 @@ export default class EscalatedProvider {
     // the core escalated routes.
     await this.bootPluginBridge()
 
-    // Register routes
-    await this.registerRoutes()
-
     // Wire AdonisJS emitter events → plugin bridge action hooks
     await this.wireEventsToBridge()
 
@@ -149,6 +146,25 @@ export default class EscalatedProvider {
 
     // Load active plugins (must happen after config is loaded)
     await this.loadPlugins()
+  }
+
+  /**
+   * Start the provider — runs *after* the app has fully booted.
+   *
+   * Route registration MUST happen here, not in `boot()`. The
+   * `@adonisjs/core/services/router` module assigns its `router` export
+   * inside an `await app.booted(...)` callback — so the value is
+   * `undefined` for any code that runs during `boot()`. Anything that
+   * depends on `router.group()` etc. needs to live in `start()`.
+   *
+   * Skipped outside of the `web` environment (ace/test contexts don't
+   * load the router service at all).
+   */
+  async start() {
+    if (this.app.getEnvironment() !== 'web') {
+      return
+    }
+    await this.registerRoutes()
   }
 
   /**

--- a/scripts/copy-build-assets.mjs
+++ b/scripts/copy-build-assets.mjs
@@ -1,0 +1,27 @@
+// Copy non-TS runtime assets into build/ so the published package is
+// self-contained — `configure.js` resolves stubs and migrations
+// relative to its own URL (build/configure.js), so the .stub files and
+// the .ts migration sources need to live alongside it under build/.
+
+import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url))
+const BUILD = join(ROOT, 'build')
+
+function copyTree(srcRel, dstRel, label) {
+  const src = join(ROOT, srcRel)
+  const dst = join(BUILD, dstRel)
+  if (!existsSync(src)) {
+    console.log(`[copy-assets] ${label}: source ${src} not found, skipping`)
+    return
+  }
+  mkdirSync(dst, { recursive: true })
+  cpSync(src, dst, { recursive: true })
+  const count = readdirSync(dst, { recursive: true }).length
+  console.log(`[copy-assets] ${label}: copied ${src} → ${dst} (${count} entries)`)
+}
+
+copyTree('stubs', 'stubs', 'stubs')
+copyTree('database/migrations', 'database/migrations', 'migrations')


### PR DESCRIPTION
## Why

Replaces the placeholder \`/demo\` HTML stub (which existed because the package wouldn't build) with the same picker → login → agent-profile flow that **dotnet #16, spring #18, and phoenix #28** ship.

Now that #34 is fully resolved (PRs #39 + #40 + #41 + #42 + #43 + #44 + #45 brought tsc errors from 396 → 0), the docker host can install the package, run \`node ace configure\` to publish the migrations, run them against postgres, and use the package's Lucid models from a normal controller.

## Demo flow

1. \`GET /\` → \`/demo\`.
2. \`GET /demo\` lazily seeds 2 departments + 3 agent profiles on first request (mirrors spring's \`@PostConstruct\` pattern but doesn't require a separate ace command), then renders an HTML picker.
3. \`POST /demo/login/:id\` returns \`303 See Other\` → \`/demo/agent/:id\` (303 because POST + 302 keeps the original method, which would land at "POST /demo/agent/:id" → 404).
4. \`GET /demo/agent/:id\` queries \`AgentProfile\` + \`Department\` from the package's models and renders the profile page with a department count to prove the migrations + seed + Lucid round-trip all work end-to-end against Postgres.

## Build infrastructure

The Dockerfile now actually installs escalated-adonis end-to-end:

1. Build a tarball of the local package source (\`npm pack\`)
2. Bootstrap a non-interactive AdonisJS host with \`--kit=api\`
3. Install the tarball + the optional peer deps the package exercises
4. \`node ace configure\` to publish config + migrations
5. Overlay the demo controller and **replace** \`start/routes.ts\` (the scaffold's default \`GET /\` would collide with the demo's redirect handler)

## Two production fixes surfaced during e2e validation

- **\`providers/escalated_provider.ts\`** — route registration moved from \`boot()\` to a new \`start()\` method. The \`@adonisjs/core/services/router\` module assigns its \`router\` export inside \`await app.booted(...)\`, so it's \`undefined\` for any code that runs during \`boot()\`. Anything that depends on \`router.group()\` has to live in \`start()\`. Also skip \`start()\` outside the \`web\` environment so ace migration runs don't trigger the route-registration path.
- **\`scripts/copy-build-assets.mjs\` (new) + \`package.json\`** — postbuild step that copies \`stubs/**/*.stub\` and \`database/migrations/*.ts\` into \`build/\` so the published package is self-contained. \`configure.js\` resolves both relative to its own URL (\`build/configure.js\`), so the assets need to live alongside it under \`build/\`. Without this, \`node ace configure\` failed with \"ENOENT: stubs/config/escalated.stub\" against any consumer.

## Verification

\`\`\`
\$ docker compose -f docker/compose.yml up --build
[demo] running migrations
... migrations succeed ...
[ info ] starting HTTP server...

\$ curl -sL http://localhost:3333/demo | grep '<h1>'
      <h1>Escalated AdonisJS Demo</h1>

\$ curl -s http://localhost:3333/demo/agent/1 | grep '<h1>'
      <h1>Logged in as Alice (Admin)</h1>
\`\`\`

Department count rendered on agent page: **2**. Three agent profiles seeded. Lucid + Postgres round-trip verified end-to-end.

This completes the adonis rollout — the placeholder \`[~]\` in \`ROLLOUT_STATUS.md\` flips to \`[x]\` once this lands.