### PR TITLE
feat(email): add MessageIdUtil for RFC 5322 threading + signed Reply-To

### DIFF
--- a/src/services/email/message_id_util.ts
+++ b/src/services/email/message_id_util.ts
@@ -1,0 +1,87 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+/**
+ * Pure helpers for RFC 5322 Message-ID threading and signed Reply-To
+ * addresses. Mirrors the NestJS reference
+ * `escalated-nestjs/src/services/email/message-id.ts` and the Spring /
+ * WordPress / .NET / Phoenix / Laravel / Rails / Django ports.
+ *
+ * ## Message-ID format
+ *   <ticket-{ticketId}@{domain}>             initial ticket email
+ *   <ticket-{ticketId}-reply-{replyId}@{domain}>  agent reply
+ *
+ * ## Signed Reply-To format
+ *   reply+{ticketId}.{hmac8}@{domain}
+ *
+ * The signed Reply-To carries ticket identity even when clients strip
+ * our Message-ID / In-Reply-To headers — the inbound provider webhook
+ * verifies the 8-char HMAC-SHA256 prefix before routing a reply to its
+ * ticket.
+ */
+
+/**
+ * Build an RFC 5322 Message-ID. Pass `null` for `replyId` on the
+ * initial ticket email; the `-reply-{id}` tail is appended only when
+ * `replyId` is non-null.
+ */
+export function buildMessageId(
+  ticketId: number,
+  replyId: number | null | undefined,
+  domain: string
+): string {
+  const body =
+    typeof replyId === 'number' && Number.isFinite(replyId)
+      ? `ticket-${ticketId}-reply-${replyId}`
+      : `ticket-${ticketId}`
+  return `<${body}@${domain}>`
+}
+
+/**
+ * Extract the ticket id from a Message-ID we issued. Accepts the
+ * header value with or without angle brackets. Returns `null` when
+ * the input doesn't match our shape.
+ */
+export function parseTicketIdFromMessageId(raw: string | null | undefined): number | null {
+  if (!raw) return null
+  const match = raw.match(/ticket-(\d+)(?:-reply-\d+)?@/i)
+  if (!match) return null
+  const n = Number(match[1])
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Build a signed Reply-To address.
+ */
+export function buildReplyTo(ticketId: number, secret: string, domain: string): string {
+  return `reply+${ticketId}.${sign(ticketId, secret)}@${domain}`
+}
+
+/**
+ * Verify a reply-to address (full `local@domain` or just the local
+ * part). Returns the ticket id on match, `null` otherwise. Uses
+ * `crypto.timingSafeEqual` for timing-safe comparison.
+ */
+export function verifyReplyTo(address: string | null | undefined, secret: string): number | null {
+  if (!address) return null
+  const at = address.indexOf('@')
+  const local = at > 0 ? address.slice(0, at) : address
+  const match = local.match(/^reply\+(\d+)\.([a-f0-9]{8})$/i)
+  if (!match) return null
+  const ticketId = Number(match[1])
+  if (!Number.isFinite(ticketId)) return null
+  const expected = sign(ticketId, secret).toLowerCase()
+  const provided = match[2].toLowerCase()
+  if (expected.length !== provided.length) return null
+  try {
+    if (timingSafeEqual(Buffer.from(expected), Buffer.from(provided))) {
+      return ticketId
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+function sign(ticketId: number, secret: string): string {
+  return createHmac('sha256', secret).update(String(ticketId)).digest('hex').slice(0, 8)
+}

--- a/tests/message_id_util.test.ts
+++ b/tests/message_id_util.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildMessageId,
+  parseTicketIdFromMessageId,
+  buildReplyTo,
+  verifyReplyTo,
+} from '../src/services/email/message_id_util.js'
+
+/*
+|--------------------------------------------------------------------------
+| MessageIdUtil unit tests
+|--------------------------------------------------------------------------
+|
+| Pure-function tests. Mirrors the NestJS / Spring / WordPress / .NET /
+| Phoenix / Laravel / Rails / Django reference suites.
+|
+*/
+
+const DOMAIN = 'support.example.com'
+const SECRET = 'test-secret-long-enough-for-hmac'
+
+describe('buildMessageId', () => {
+  it('uses the ticket form when replyId is null', () => {
+    assert.equal(buildMessageId(42, null, DOMAIN), '<ticket-42@support.example.com>')
+  })
+
+  it('uses the ticket form when replyId is undefined', () => {
+    assert.equal(buildMessageId(42, undefined, DOMAIN), '<ticket-42@support.example.com>')
+  })
+
+  it('appends -reply-{id} when replyId is a number', () => {
+    assert.equal(buildMessageId(42, 7, DOMAIN), '<ticket-42-reply-7@support.example.com>')
+  })
+})
+
+describe('parseTicketIdFromMessageId', () => {
+  it('round-trips built Message-IDs', () => {
+    assert.equal(parseTicketIdFromMessageId(buildMessageId(42, null, DOMAIN)), 42)
+    assert.equal(parseTicketIdFromMessageId(buildMessageId(42, 7, DOMAIN)), 42)
+  })
+
+  it('accepts values without angle brackets', () => {
+    assert.equal(parseTicketIdFromMessageId('ticket-99@example.com'), 99)
+  })
+
+  it('returns null for nil, empty, or unrelated input', () => {
+    assert.equal(parseTicketIdFromMessageId(null), null)
+    assert.equal(parseTicketIdFromMessageId(undefined), null)
+    assert.equal(parseTicketIdFromMessageId(''), null)
+    assert.equal(parseTicketIdFromMessageId('<random@mail.com>'), null)
+    assert.equal(parseTicketIdFromMessageId('ticket-abc@example.com'), null)
+  })
+})
+
+describe('buildReplyTo', () => {
+  it('is stable for the same inputs', () => {
+    const first = buildReplyTo(42, SECRET, DOMAIN)
+    const again = buildReplyTo(42, SECRET, DOMAIN)
+    assert.equal(first, again)
+    assert.match(first, /^reply\+42\.[a-f0-9]{8}@support\.example\.com$/)
+  })
+
+  it('produces different signatures across tickets', () => {
+    const a = buildReplyTo(42, SECRET, DOMAIN)
+    const b = buildReplyTo(43, SECRET, DOMAIN)
+    assert.notEqual(a.split('@')[0], b.split('@')[0])
+  })
+})
+
+describe('verifyReplyTo', () => {
+  it('round-trips a built address', () => {
+    const address = buildReplyTo(42, SECRET, DOMAIN)
+    assert.equal(verifyReplyTo(address, SECRET), 42)
+  })
+
+  it('accepts the local part only', () => {
+    const address = buildReplyTo(42, SECRET, DOMAIN)
+    const local = address.split('@')[0]
+    assert.equal(verifyReplyTo(local, SECRET), 42)
+  })
+
+  it('rejects a tampered signature', () => {
+    const address = buildReplyTo(42, SECRET, DOMAIN)
+    const at = address.indexOf('@')
+    const local = address.slice(0, at)
+    const last = local[local.length - 1]
+    const tampered = local.slice(0, -1) + (last === '0' ? '1' : '0') + address.slice(at)
+    assert.equal(verifyReplyTo(tampered, SECRET), null)
+  })
+
+  it('rejects a wrong secret', () => {
+    const address = buildReplyTo(42, SECRET, DOMAIN)
+    assert.equal(verifyReplyTo(address, 'different-secret'), null)
+  })
+
+  it('rejects malformed input', () => {
+    assert.equal(verifyReplyTo(null, SECRET), null)
+    assert.equal(verifyReplyTo(undefined, SECRET), null)
+    assert.equal(verifyReplyTo('', SECRET), null)
+    assert.equal(verifyReplyTo('alice@example.com', SECRET), null)
+    assert.equal(verifyReplyTo('reply@example.com', SECRET), null)
+    assert.equal(verifyReplyTo('reply+abc.deadbeef@example.com', SECRET), null)
+  })
+
+  it('is case-insensitive on the hex signature', () => {
+    const address = buildReplyTo(42, SECRET, DOMAIN)
+    assert.equal(verifyReplyTo(address.toUpperCase(), SECRET), 42)
+  })
+})


### PR DESCRIPTION
## Summary

Ports the NestJS `email/message-id.ts` helpers to Adonis. Mirrors the Spring / WordPress / .NET / Phoenix / Laravel / Rails / Django ports (8 of 11 framework ports shipped).

## API

- `buildMessageId(ticketId, replyId, domain)`
- `parseTicketIdFromMessageId(raw)`
- `buildReplyTo(ticketId, secret, domain)`
- `verifyReplyTo(address, secret)`

Uses `node:crypto` `createHmac` + `timingSafeEqual` for timing-safe verification.

## Scope

**Utility only.** Follow-up PR will integrate with `EmailThreadingService` so outbound notifications adopt the NestJS-compatible Message-ID format plus signed Reply-To headers.

## Test plan

- [x] 12 node:test tests covering round-trip, tamper rejection, case-insensitive hex, malformed input, local-part-only
- [ ] CI green: Lint & Format + Node 20/22