### PR TITLE
feat(admin): public-tickets (guest policy) settings endpoint

### DIFF
--- a/src/controllers/admin_settings_controller.ts
+++ b/src/controllers/admin_settings_controller.ts
@@ -117,6 +117,54 @@ export default class AdminSettingsController {
     }
   }
 
+  /**
+   * Public-ticket guest policy settings page.
+   *
+   * Controls the identity assigned to tickets submitted via the public widget
+   * or inbound email. Read at request time by the widget controller, so
+   * admins can switch modes at runtime without a redeploy.
+   */
+  async publicTickets(ctx: HttpContext) {
+    const userIdRaw = await EscalatedSetting.get('guest_policy_user_id', '')
+    const parsedUserId = userIdRaw && /^\d+$/.test(userIdRaw) ? Number.parseInt(userIdRaw, 10) : null
+
+    return getRenderer().render(ctx, 'Escalated/Admin/Settings/PublicTickets', {
+      settings: {
+        guest_policy_mode: await EscalatedSetting.get('guest_policy_mode', 'unassigned'),
+        guest_policy_user_id: parsedUserId,
+        guest_policy_signup_url_template: await EscalatedSetting.get(
+          'guest_policy_signup_url_template',
+          ''
+        ),
+      },
+    })
+  }
+
+  async updatePublicTickets({ request, response, session }: HttpContext) {
+    const modeRaw = request.input('guest_policy_mode', 'unassigned')
+    const mode =
+      modeRaw === 'guest_user' || modeRaw === 'prompt_signup' ? modeRaw : 'unassigned'
+
+    await EscalatedSetting.set('guest_policy_mode', mode)
+
+    if (mode === 'guest_user') {
+      const userId = Number.parseInt(String(request.input('guest_policy_user_id', '')), 10)
+      await EscalatedSetting.set('guest_policy_user_id', userId > 0 ? String(userId) : '')
+    } else {
+      await EscalatedSetting.set('guest_policy_user_id', '')
+    }
+
+    if (mode === 'prompt_signup') {
+      const template = String(request.input('guest_policy_signup_url_template', '')).slice(0, 500)
+      await EscalatedSetting.set('guest_policy_signup_url_template', template)
+    } else {
+      await EscalatedSetting.set('guest_policy_signup_url_template', '')
+    }
+
+    session.flash('success', t('admin.settings_updated'))
+    return response.redirect().back()
+  }
+
   protected isMaskedValue(value: string | null): boolean {
     if (!value) return false
     return /^.{0,3}\*{3,}$/.test(value)

--- a/src/controllers/admin_settings_controller.ts
+++ b/src/controllers/admin_settings_controller.ts
@@ -126,7 +126,8 @@ export default class AdminSettingsController {
    */
   async publicTickets(ctx: HttpContext) {
     const userIdRaw = await EscalatedSetting.get('guest_policy_user_id', '')
-    const parsedUserId = userIdRaw && /^\d+$/.test(userIdRaw) ? Number.parseInt(userIdRaw, 10) : null
+    const parsedUserId =
+      userIdRaw && /^\d+$/.test(userIdRaw) ? Number.parseInt(userIdRaw, 10) : null
 
     return getRenderer().render(ctx, 'Escalated/Admin/Settings/PublicTickets', {
       settings: {
@@ -142,8 +143,7 @@ export default class AdminSettingsController {
 
   async updatePublicTickets({ request, response, session }: HttpContext) {
     const modeRaw = request.input('guest_policy_mode', 'unassigned')
-    const mode =
-      modeRaw === 'guest_user' || modeRaw === 'prompt_signup' ? modeRaw : 'unassigned'
+    const mode = modeRaw === 'guest_user' || modeRaw === 'prompt_signup' ? modeRaw : 'unassigned'
 
     await EscalatedSetting.set('guest_policy_mode', mode)
 

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -381,6 +381,14 @@ function registerUiRoutes(config: any) {
         .post('/settings', [AdminSettingsController, 'update'])
         .as('escalated.admin.settings.update')
 
+      // Public-ticket (guest policy) settings
+      router
+        .get('/settings/public-tickets', [AdminSettingsController, 'publicTickets'])
+        .as('escalated.admin.settings.public-tickets')
+      router
+        .put('/settings/public-tickets', [AdminSettingsController, 'updatePublicTickets'])
+        .as('escalated.admin.settings.public-tickets.update')
+
       // Departments CRUD
       router
         .get('/departments', [AdminDepartmentsController, 'index'])


### PR DESCRIPTION
## Summary

AdonisJS host-adapter side of the new \`Admin/Settings/PublicTickets.vue\` page ([escalated#32](https://github.com/escalated-dev/escalated/pull/32)).

## What's added

- \`AdminSettingsController#publicTickets\` — renders the Vue page with current guest-policy values.
- \`AdminSettingsController#updatePublicTickets\` — validates mode against the three supported values (\`unassigned\`, \`guest_user\`, \`prompt_signup\`) and persists via \`EscalatedSetting\`.
- Two named routes: \`escalated.admin.settings.public-tickets\` (GET) and \`escalated.admin.settings.public-tickets.update\` (PUT).

## Behavior

- Unknown modes fall back to \`unassigned\`.
- \`guest_policy_user_id\` is only persisted when mode is \`guest_user\` (positive integer).
- \`guest_policy_signup_url_template\` is only persisted when mode is \`prompt_signup\`, capped at 500 chars.
- Switching modes clears the fields that no longer apply so stale values don't leak.

## Test plan

- [ ] \`npx tsc --noEmit\` — green locally.
- [ ] \`node ace list:routes | grep public-tickets\` shows both routes after merge.