### PR TITLE
fix(public-tickets): honor guest_policy_mode on widget + guest submissions

### DIFF
--- a/src/controllers/guest_tickets_controller.ts
+++ b/src/controllers/guest_tickets_controller.ts
@@ -57,10 +57,13 @@ export default class GuestTicketsController {
     // remain populated for the backwards-compat dual-read period.
     const contact = await Contact.findOrCreateByEmail(data.guest_email, data.guest_name)
 
+    const { resolveGuestPolicy } = await import('../helpers/guest_policy.js')
+    const policy = await resolveGuestPolicy()
+
     const ticket = await Ticket.create({
       reference: await Ticket.generateReference(),
-      requesterType: null,
-      requesterId: null,
+      requesterType: policy.requesterType,
+      requesterId: policy.requesterId,
       guestName: data.guest_name,
       guestEmail: data.guest_email,
       guestToken: string.random(64),

--- a/src/controllers/widget_controller.ts
+++ b/src/controllers/widget_controller.ts
@@ -91,16 +91,18 @@ export default class WidgetController {
     }
 
     const { randomBytes } = await import('node:crypto')
+    const { resolveGuestPolicy } = await import('../helpers/guest_policy.js')
     const guestToken = randomBytes(32).toString('hex')
     const reference = await Ticket.generateReference()
+    const policy = await resolveGuestPolicy()
 
     // Dedupe repeat submitters by email (Pattern B).
     const contact = await Contact.findOrCreateByEmail(data.email, data.name)
 
     const ticket = await Ticket.create({
       reference,
-      requesterType: null,
-      requesterId: null,
+      requesterType: policy.requesterType,
+      requesterId: policy.requesterId,
       guestName: data.name || null,
       guestEmail: data.email,
       guestToken,

--- a/src/helpers/guest_policy.ts
+++ b/src/helpers/guest_policy.ts
@@ -1,0 +1,44 @@
+import EscalatedSetting from '../models/escalated_setting.js'
+import { getConfig } from './config.js'
+
+export interface GuestPolicyOverrides {
+  requesterType: string | null
+  requesterId: number | null
+}
+
+/**
+ * Resolve the admin-configured guest policy into a
+ * `{ requesterType, requesterId }` pair that the caller spreads onto
+ * its ticket-create attrs. Persisted by AdminSettingsController under
+ * three keys in EscalatedSetting (guest_policy_mode /
+ * guest_policy_user_id / guest_policy_signup_url_template).
+ *
+ * Modes:
+ *   - unassigned (default): both null.
+ *   - guest_user: route to a pre-created host-app user via
+ *     `requesterType = config.userModel` + `requesterId =
+ *     guest_policy_user_id`. Falls through to unassigned behavior if
+ *     `guest_policy_user_id` is zero, missing, or non-numeric.
+ *   - prompt_signup: same as unassigned today; signup-invite emission
+ *     is a listener-level follow-up.
+ *
+ * Returning only the two fields (rather than mutating a whole attrs
+ * object) keeps TypeScript literal-type inference intact at the call
+ * site — the caller's `status: 'open'` stays typed as `TicketStatus`.
+ */
+export async function resolveGuestPolicy(): Promise<GuestPolicyOverrides> {
+  const mode = (await EscalatedSetting.get('guest_policy_mode')) || 'unassigned'
+
+  if (mode === 'guest_user') {
+    const raw = (await EscalatedSetting.get('guest_policy_user_id')) || ''
+    const userId = Number.parseInt(raw, 10)
+    if (Number.isFinite(userId) && userId > 0) {
+      return {
+        requesterType: getConfig().userModel,
+        requesterId: userId,
+      }
+    }
+  }
+
+  return { requesterType: null, requesterId: null }
+}


### PR DESCRIPTION
## Summary

Fifth framework in the cross-framework fix sweep for the widget↔settings-disconnection bug — same behavioral defect as [escalated-laravel#72](https://github.com/escalated-dev/escalated-laravel/pull/72), [escalated-rails#47](https://github.com/escalated-dev/escalated-rails/pull/47), [escalated-django#44](https://github.com/escalated-dev/escalated-django/pull/44), and [escalated-nestjs#27](https://github.com/escalated-dev/escalated-nestjs/pull/27).

Adonis's \`AdminSettingsController\` (shipped in #51) persists \`guest_policy_mode\` / \`guest_policy_user_id\` / \`guest_policy_signup_url_template\` to \`EscalatedSetting\`, but both public submission paths — \`WidgetController#createTicket\` and \`GuestTicketsController#store\` — wrote \`requesterType=null\`, \`requesterId=null\`, \`guest*\` fields unconditionally. **Result: the admin settings page had zero behavioral effect.**

## What's added

New helper \`src/helpers/guest_policy.ts\` exposing \`resolveGuestPolicy()\` that reads the 3 keys from \`EscalatedSetting\` and returns just \`{ requesterType, requesterId }\` — the caller spreads these onto their own attrs. Returning only the two overridden fields (instead of mutating the whole attrs object) preserves TypeScript's literal-type inference on sibling fields like \`status: 'open'\` so the \`TicketStatus\` enum typing stays intact.

Both entry points wire through it:

| Mode | Behavior |
|---|---|
| \`unassigned\` (default) | Existing behavior — \`requesterType\`/\`requesterId\` both null, \`guest*\` fields set. |
| \`guest_user\` | Routes to the configured host user: \`requesterType = config.userModel\`, \`requesterId = guest_policy_user_id\`. Still records guest name/email. |
| \`prompt_signup\` | Same ticket-create path as unassigned. Signup-invite emission is a listener-level follow-up. |

Misconfigured \`guest_user\` (zero / non-numeric user id) falls through to unassigned so bad admin input can't 500 public submissions.

## Test plan

- [x] \`npx tsc --noEmit\` — clean.
- [x] \`npm run lint\` — clean.
- [x] \`npm test\` — 458/458 pass.

## Running scoreboard

NestJS #27, Laravel #72, Rails #47, Django #44, Adonis #52 — **5 of 6 frameworks done**. Only WordPress still to go for the same bug.