### PR TITLE
fix(inbound): honor guest_policy_mode on inbound-email-created tickets

### DIFF
--- a/src/controllers/guest_tickets_controller.ts
+++ b/src/controllers/guest_tickets_controller.ts
@@ -52,10 +52,13 @@ export default class GuestTicketsController {
       'department_id',
     ])
 
+    const { resolveGuestPolicy } = await import('../helpers/guest_policy.js')
+    const policy = await resolveGuestPolicy()
+
     const ticket = await Ticket.create({
       reference: await Ticket.generateReference(),
-      requesterType: null,
-      requesterId: null,
+      requesterType: policy.requesterType,
+      requesterId: policy.requesterId,
       guestName: data.guest_name,
       guestEmail: data.guest_email,
       guestToken: string.random(64),

--- a/src/controllers/widget_controller.ts
+++ b/src/controllers/widget_controller.ts
@@ -90,13 +90,15 @@ export default class WidgetController {
     }
 
     const { randomBytes } = await import('node:crypto')
+    const { resolveGuestPolicy } = await import('../helpers/guest_policy.js')
     const guestToken = randomBytes(32).toString('hex')
     const reference = await Ticket.generateReference()
+    const policy = await resolveGuestPolicy()
 
     const ticket = await Ticket.create({
       reference,
-      requesterType: null,
-      requesterId: null,
+      requesterType: policy.requesterType,
+      requesterId: policy.requesterId,
       guestName: data.name || null,
       guestEmail: data.email,
       guestToken,

--- a/src/helpers/guest_policy.ts
+++ b/src/helpers/guest_policy.ts
@@ -1,0 +1,44 @@
+import EscalatedSetting from '../models/escalated_setting.js'
+import { getConfig } from './config.js'
+
+export interface GuestPolicyOverrides {
+  requesterType: string | null
+  requesterId: number | null
+}
+
+/**
+ * Resolve the admin-configured guest policy into a
+ * `{ requesterType, requesterId }` pair that the caller spreads onto
+ * its ticket-create attrs. Persisted by AdminSettingsController under
+ * three keys in EscalatedSetting (guest_policy_mode /
+ * guest_policy_user_id / guest_policy_signup_url_template).
+ *
+ * Modes:
+ *   - unassigned (default): both null.
+ *   - guest_user: route to a pre-created host-app user via
+ *     `requesterType = config.userModel` + `requesterId =
+ *     guest_policy_user_id`. Falls through to unassigned behavior if
+ *     `guest_policy_user_id` is zero, missing, or non-numeric.
+ *   - prompt_signup: same as unassigned today; signup-invite emission
+ *     is a listener-level follow-up.
+ *
+ * Returning only the two fields (rather than mutating a whole attrs
+ * object) keeps TypeScript literal-type inference intact at the call
+ * site — the caller's `status: 'open'` stays typed as `TicketStatus`.
+ */
+export async function resolveGuestPolicy(): Promise<GuestPolicyOverrides> {
+  const mode = (await EscalatedSetting.get('guest_policy_mode')) || 'unassigned'
+
+  if (mode === 'guest_user') {
+    const raw = (await EscalatedSetting.get('guest_policy_user_id')) || ''
+    const userId = Number.parseInt(raw, 10)
+    if (Number.isFinite(userId) && userId > 0) {
+      return {
+        requesterType: getConfig().userModel,
+        requesterId: userId,
+      }
+    }
+  }
+
+  return { requesterType: null, requesterId: null }
+}

--- a/src/services/inbound_email_service.ts
+++ b/src/services/inbound_email_service.ts
@@ -172,13 +172,16 @@ export default class InboundEmailService {
       })
     }
 
-    // Guest ticket
+    // Guest ticket — apply the admin-configured guest policy. Same
+    // helper used by WidgetController#createTicket (see #52).
     const { default: stringHelper } = await import('@adonisjs/core/helpers/string')
+    const { resolveGuestPolicy } = await import('../helpers/guest_policy.js')
+    const policy = await resolveGuestPolicy()
 
     const ticket = await Ticket.create({
       reference: await Ticket.generateReference(),
-      requesterType: null,
-      requesterId: null,
+      requesterType: policy.requesterType,
+      requesterId: policy.requesterId,
       guestName: message.fromName || this.nameFromEmail(message.fromEmail),
       guestEmail: message.fromEmail,
       guestToken: stringHelper.random(64),


### PR DESCRIPTION
## Summary

Second wave of the widget↔settings-disconnection sweep. Mirrors [escalated-nestjs#28](https://github.com/escalated-dev/escalated-nestjs/pull/28), [escalated-laravel#73](https://github.com/escalated-dev/escalated-laravel/pull/73), [escalated-rails#48](https://github.com/escalated-dev/escalated-rails/pull/48), [escalated-django#45](https://github.com/escalated-dev/escalated-django/pull/45).

\`InboundEmailService#createNewTicket\` wrote \`requesterType=null\`, \`requesterId=null\`, \`guest*\` fields unconditionally for non-registered senders — ignoring the admin-configured \`guest_policy_mode\`.

## What changed

Wired through the \`resolveGuestPolicy()\` helper factored in [#52](https://github.com/escalated-dev/escalated-adonis/pull/52) (the widget fix). Inbound service inherits identical semantics:

| Mode | Behavior |
|---|---|
| \`unassigned\` (default) | \`requester*\` null, \`guest*\` set. |
| \`guest_user\` | \`requesterType = config.userModel\`, \`requesterId = guest_policy_user_id\`. Records \`guestName\` / \`guestEmail\`. |
| \`prompt_signup\` | Unassigned ticket path; signup invite is a listener follow-up. |

Misconfigured \`guest_user\` (zero / non-numeric user id) falls through to unassigned.

## Stacking

Stacked on \`fix/widget-honors-guest-policy\` because the helper file lives there.

## Test plan

- [x] No new test file — the helper is covered by the 4 widget tests in #52; inbound service just calls the same helper.
- [x] Full test suite: 458/458 pass.
- [x] \`tsc --noEmit\` + lint clean.

## Related

NestJS #28, Laravel #73, Rails #48, Django #45 (this sweep). WordPress still to go.