### PR TITLE
feat(email): wire MessageIdUtil into EmailThreadingService + signed Reply-To

### DIFF
--- a/src/services/email_threading_service.ts
+++ b/src/services/email_threading_service.ts
@@ -1,36 +1,47 @@
-import { createHash } from 'node:crypto'
+import { buildMessageId, buildReplyTo } from './email/message_id_util.js'
 import EscalatedSetting from '../models/escalated_setting.js'
 
 /**
  * Service for generating email threading headers and branded email content.
  *
  * Ensures outbound emails include proper In-Reply-To, References, and
- * Message-ID headers so mail clients group ticket conversations into threads.
+ * Message-ID headers so mail clients group ticket conversations into
+ * threads. Delegates Message-ID generation to `MessageIdUtil` so the
+ * format matches the canonical NestJS reference and inbound Reply-To
+ * verification has something to check against.
  */
 export default class EmailThreadingService {
   /**
-   * Generate a unique Message-ID for an outbound email.
+   * Generate the Message-ID for an outbound email. For initial ticket
+   * notifications pass `replyId = null`; for agent replies pass the
+   * reply id so the Message-ID carries `-reply-{replyId}`.
    */
   generateMessageId(ticketId: number, replyId: number | null, domain: string): string {
-    const unique = replyId ? `reply-${replyId}` : `ticket-${ticketId}`
-    const hash = createHash('sha256')
-      .update(`escalated-${unique}-${Date.now()}`)
-      .digest('hex')
-      .slice(0, 16)
-    return `<escalated-${unique}-${hash}@${domain}>`
+    return buildMessageId(ticketId, replyId, domain)
   }
 
   /**
    * Generate the root Message-ID for a ticket (used as the thread anchor).
    */
   generateTicketMessageId(ticketId: number, domain: string): string {
-    return `<escalated-ticket-${ticketId}@${domain}>`
+    return buildMessageId(ticketId, null, domain)
+  }
+
+  /**
+   * Build a signed Reply-To address (`reply+{id}.{hmac8}@{domain}`) so
+   * inbound provider webhooks can verify ticket identity even when
+   * clients strip our Message-ID / In-Reply-To headers. Returns `null`
+   * when `secret` is blank (signing disabled).
+   */
+  buildSignedReplyTo(ticketId: number, domain: string, secret: string): string | null {
+    if (!secret) return null
+    return buildReplyTo(ticketId, secret, domain)
   }
 
   /**
    * Build threading headers for an outbound reply email.
    *
-   * - Message-ID: unique per email
+   * - Message-ID: canonical `<ticket-{id}(-reply-{replyId})?@{domain}>`
    * - In-Reply-To: the ticket's root Message-ID (or the inbound message-id if replying to one)
    * - References: chain of Message-IDs for the thread
    */

--- a/tests/email_threading_service.test.ts
+++ b/tests/email_threading_service.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import EmailThreadingService from '../src/services/email_threading_service.js'
+import { verifyReplyTo } from '../src/services/email/message_id_util.js'
+
+/*
+|--------------------------------------------------------------------------
+| EmailThreadingService (MessageIdUtil wire-up)
+|--------------------------------------------------------------------------
+|
+| Verifies that the threading service now delegates to MessageIdUtil so
+| the Message-ID format matches the canonical NestJS reference and the
+| signed Reply-To round-trips through verifyReplyTo.
+|
+*/
+
+const DOMAIN = 'support.example.com'
+const SECRET = 'test-secret-for-hmac'
+
+describe('EmailThreadingService.generateTicketMessageId', () => {
+  it('produces the canonical ticket-{id} anchor', () => {
+    const svc = new EmailThreadingService()
+    assert.equal(svc.generateTicketMessageId(42, DOMAIN), '<ticket-42@support.example.com>')
+  })
+})
+
+describe('EmailThreadingService.generateMessageId', () => {
+  it('uses the anchor form when replyId is null', () => {
+    const svc = new EmailThreadingService()
+    assert.equal(svc.generateMessageId(42, null, DOMAIN), '<ticket-42@support.example.com>')
+  })
+
+  it('appends -reply-{id} for reply emails', () => {
+    const svc = new EmailThreadingService()
+    assert.equal(svc.generateMessageId(42, 7, DOMAIN), '<ticket-42-reply-7@support.example.com>')
+  })
+})
+
+describe('EmailThreadingService.buildSignedReplyTo', () => {
+  it('returns null when secret is blank', () => {
+    const svc = new EmailThreadingService()
+    assert.equal(svc.buildSignedReplyTo(42, DOMAIN, ''), null)
+  })
+
+  it('returns a signed address that verifyReplyTo round-trips', () => {
+    const svc = new EmailThreadingService()
+    const address = svc.buildSignedReplyTo(42, DOMAIN, SECRET)
+    assert.ok(address)
+    assert.match(address!, /^reply\+42\.[a-f0-9]{8}@support\.example\.com$/)
+    assert.equal(verifyReplyTo(address, SECRET), 42)
+  })
+
+  it('produces different signatures for different tickets', () => {
+    const svc = new EmailThreadingService()
+    const a = svc.buildSignedReplyTo(42, DOMAIN, SECRET)
+    const b = svc.buildSignedReplyTo(43, DOMAIN, SECRET)
+    assert.notEqual(a!.split('@')[0], b!.split('@')[0])
+  })
+})
+
+describe('EmailThreadingService.buildThreadingHeaders', () => {
+  it('sets Message-ID, In-Reply-To, and References for replies', () => {
+    const svc = new EmailThreadingService()
+    const headers = svc.buildThreadingHeaders(42, 7, DOMAIN)
+
+    assert.equal(headers['Message-ID'], '<ticket-42-reply-7@support.example.com>')
+    assert.equal(headers['In-Reply-To'], '<ticket-42@support.example.com>')
+    assert.equal(headers['References'], '<ticket-42@support.example.com>')
+  })
+
+  it('uses the inbound Message-ID for In-Reply-To when provided', () => {
+    const svc = new EmailThreadingService()
+    const inbound = '<CABC@mail.client.example.com>'
+    const headers = svc.buildThreadingHeaders(42, 7, DOMAIN, inbound)
+
+    assert.equal(headers['In-Reply-To'], inbound)
+    // Ticket root still present in References chain.
+    assert.match(headers['References'], /<ticket-42@support\.example\.com>/)
+    // Inbound id also present.
+    assert.ok(headers['References'].includes(inbound))
+  })
+})


### PR DESCRIPTION
Recovers auto-closed #49 (base feat/email-message-id squash-merged via #48). Rebased onto current main.