### PR TITLE
chore(deps): upgrade to AdonisJS 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     labels:
-      - "dependencies"
+      - 'dependencies'
 
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     labels:
-      - "dependencies"
+      - 'dependencies'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 20]
+        node: [24]
 
     name: Node ${{ matrix.node }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- **BREAKING**: Upgraded to AdonisJS v7. Host applications must be on AdonisJS Core ^7.0, Lucid ^22.0, Auth ^10.0, Inertia ^4.0, Drive ^4.0, Mail ^10.0, and Node.js 24+. Bundles Dependabot updates #58 (auth 10.1), #59 (drive 4.0), #60 (lucid 22.4), #62 (session 8.1).
+- Internal: replaced `response.redirect().toRoute(name)` with a small `redirectToRoute` helper to bypass v7's strict, host-augmented `RoutesList` types in plugin code (runtime semantics unchanged).
+- Internal: widened `InertiaPages` via `@adonisjs/inertia/types` augmentation so the package's render calls type-check standalone.
+
 ## [0.4.0] - 2026-02-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@
 # Escalated for AdonisJS
 
 [![Tests](https://github.com/escalated-dev/escalated-adonis/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated-adonis/actions/workflows/run-tests.yml)
-[![AdonisJS](https://img.shields.io/badge/adonisjs-v6-5A45FF?logo=adonisjs&logoColor=white)](https://adonisjs.com/)
+[![AdonisJS](https://img.shields.io/badge/adonisjs-v7-5A45FF?logo=adonisjs&logoColor=white)](https://adonisjs.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for AdonisJS v6. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+A full-featured, embeddable support ticket system for AdonisJS v7. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
 
 > **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
 
 ## Requirements
 
-- AdonisJS v6 (Core ^6.0)
-- @adonisjs/lucid ^21.0
-- @adonisjs/auth ^9.0
-- @adonisjs/inertia ^1.0
-- @adonisjs/drive ^3.0 (for file attachments)
-- @adonisjs/mail ^9.0 (optional, for notifications)
-- Node.js 20+
+- AdonisJS v7 (Core ^7.0)
+- @adonisjs/lucid ^22.0
+- @adonisjs/auth ^10.0
+- @adonisjs/inertia ^4.0
+- @adonisjs/drive ^4.0 (for file attachments)
+- @adonisjs/mail ^10.0 (optional, for notifications)
+- Node.js 24+
 
 ## Installation
 
@@ -508,7 +508,7 @@ export default definePlugin({
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
 - **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package (you are here)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v7 package (you are here)
 - **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
 - **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
 

--- a/configure.ts
+++ b/configure.ts
@@ -33,7 +33,7 @@ export async function configure(command: ConfigureCommand) {
   /**
    * Publish migrations
    *
-   * AdonisJS 6 removed `command.publishMigrations`. Replicate its behaviour
+   * AdonisJS 6+ removed `command.publishMigrations`. Replicate its behaviour
    * with `node:fs/promises`: copy every shipped migration into the host
    * app's `database/migrations/` directory with a unique timestamp prefix so
    * the migrator runs them after the host's own migrations.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 # package's models and schema work end-to-end. Mirrors the pattern shipped
 # in dotnet #16, spring #18, and phoenix #28.
 
-FROM node:22-alpine AS host
+FROM node:24-alpine AS host
 
 RUN apk add --no-cache git
 
@@ -47,11 +47,11 @@ RUN npm install -g create-adonisjs --silent && \
 RUN cp /pkg-out/escalated-dev-escalated-adonis-*.tgz /host/escalated-adonis.tgz && \
     npm install --no-audit --no-fund --legacy-peer-deps \
         ./escalated-adonis.tgz \
-        @adonisjs/auth@^9 \
-        @adonisjs/cache@^1 \
-        @adonisjs/drive@^3 \
-        @adonisjs/inertia@^1 \
-        @adonisjs/mail@^9 \
+        @adonisjs/auth@^10 \
+        @adonisjs/cache@^2 \
+        @adonisjs/drive@^4 \
+        @adonisjs/inertia@^4 \
+        @adonisjs/mail@^10 \
         luxon
 
 # 4) Configure the package — publishes config + migrations into the host.
@@ -66,7 +66,7 @@ RUN node ace.js configure @escalated-dev/escalated-adonis --force
 COPY docker/host-app/demo_controller.ts /host/app/controllers/demo_controller.ts
 COPY docker/host-app/demo_routes.ts /host/start/routes.ts
 
-FROM node:22-alpine AS runtime
+FROM node:24-alpine AS runtime
 
 RUN apk add --no-cache postgresql-client
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,17 +14,17 @@
         "luxon": "^3.7.2"
       },
       "devDependencies": {
-        "@adonisjs/auth": "^9.2.0",
-        "@adonisjs/cache": "^1.0.0",
-        "@adonisjs/core": "^6.14.0",
-        "@adonisjs/drive": "^3.0.0",
+        "@adonisjs/auth": "^10.1.0",
+        "@adonisjs/cache": "^2.1.0",
+        "@adonisjs/core": "^7.3.2",
+        "@adonisjs/drive": "^4.0.0",
         "@adonisjs/eslint-config": "^3.0.0",
-        "@adonisjs/inertia": "^1.2.0",
-        "@adonisjs/lucid": "^21.3.0",
-        "@adonisjs/mail": "^9.0.0",
+        "@adonisjs/inertia": "^4.2.0",
+        "@adonisjs/lucid": "^22.4.2",
+        "@adonisjs/mail": "^10.2.0",
         "@adonisjs/prettier-config": "^1.4.5",
-        "@adonisjs/session": "^7.6.0",
-        "@adonisjs/transmit": "^2.0.0",
+        "@adonisjs/session": "^8.1.0",
+        "@adonisjs/transmit": "^3.0.1",
         "@japa/runner": "^5.3.0",
         "@types/adm-zip": "^0.5.5",
         "@types/luxon": "^3.7.1",
@@ -33,15 +33,18 @@
         "prettier": "^3.8.1",
         "typescript": "^5.4.0"
       },
+      "engines": {
+        "node": ">=24.0.0"
+      },
       "peerDependencies": {
-        "@adonisjs/auth": "^9.0.0",
-        "@adonisjs/cache": "^1.0.0",
-        "@adonisjs/core": "^6.0.0",
-        "@adonisjs/drive": "^3.0.0",
-        "@adonisjs/inertia": "^1.0.0",
-        "@adonisjs/lucid": "^21.0.0",
-        "@adonisjs/mail": "^9.0.0",
-        "@adonisjs/transmit": "^2.0.0",
+        "@adonisjs/auth": "^10.0.0",
+        "@adonisjs/cache": "^2.0.0",
+        "@adonisjs/core": "^7.0.0",
+        "@adonisjs/drive": "^4.0.0",
+        "@adonisjs/inertia": "^4.0.0",
+        "@adonisjs/lucid": "^22.0.0",
+        "@adonisjs/mail": "^10.0.0",
+        "@adonisjs/transmit": "^3.0.0",
         "adm-zip": "^0.5.0"
       },
       "peerDependenciesMeta": {
@@ -61,104 +64,114 @@
       "license": "MIT"
     },
     "node_modules/@adonisjs/ace": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/ace/-/ace-13.4.0.tgz",
-      "integrity": "sha512-7Wq6CpXmQm3m/6fKfzubAadCdiH2kKSni+K8s5KcTIFryKSqW+f06UAPOUwRJWqy80hnVlujAjveIsNJSPeJjA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/ace/-/ace-14.1.0.tgz",
+      "integrity": "sha512-8N8z1YKePBiXz7wLxHFz/HSqjCRSL/9Vzs4XQt8gk8G17u4PXwNncWt0vSgYEcDrvPAt+QOavY1vMeKOOWe29w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/cliui": "^6.4.1",
-        "@poppinss/hooks": "^7.2.4",
-        "@poppinss/macroable": "^1.0.3",
-        "@poppinss/prompts": "^3.1.3",
-        "@poppinss/utils": "^6.8.3",
+        "@poppinss/cliui": "^6.8.0",
+        "@poppinss/hooks": "^7.3.0",
+        "@poppinss/macroable": "^1.1.2",
+        "@poppinss/prompts": "^3.1.6",
+        "@poppinss/utils": "^7.0.1",
         "fastest-levenshtein": "^1.0.16",
-        "jsonschema": "^1.4.1",
-        "string-width": "^7.2.0",
-        "yargs-parser": "^21.1.1",
-        "youch": "^3.3.4",
-        "youch-terminal": "^2.2.3"
+        "jsonschema": "^1.5.0",
+        "string-width": "^8.2.0",
+        "yargs-parser": "^22.0.0"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
+      },
+      "peerDependencies": {
+        "youch": "^4.1.0-beta.11 || ^4.1.0"
+      }
+    },
+    "node_modules/@adonisjs/ace/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
       }
     },
     "node_modules/@adonisjs/application": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/application/-/application-8.4.2.tgz",
-      "integrity": "sha512-gxyQgl1n7M/hv7ZKQOlTo2adBMehjEO0ssWSG3AGW2RXdCvkHQKlatFXMuXJMmGg2P1AWJX0LEiXey9+qxC9Uw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/application/-/application-9.0.0.tgz",
+      "integrity": "sha512-iQpq/JRJsnrqOMHfu72CYjmlkH5FwT28DhUKEOjktccmFh8OLdVZ2Sieb8b2/qNv4c+w8Yo7keOGEzOYUrU+kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/hooks": "^7.2.5",
-        "@poppinss/macroable": "^1.0.4",
-        "@poppinss/utils": "^6.9.3",
+        "@poppinss/hooks": "^7.3.0",
+        "@poppinss/macroable": "^1.1.0",
+        "@poppinss/utils": "^7.0.0",
         "glob-parent": "^6.0.2",
         "tempura": "^0.4.1"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/config": "^5.0.0",
-        "@adonisjs/fold": "^10.0.0"
+        "@adonisjs/assembler": "^8.0.0-next.23 || ^8.0.0",
+        "@adonisjs/config": "^6.1.0-next.0 || ^6.0.0",
+        "@adonisjs/fold": "^11.0.0-next.3 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@adonisjs/assembler": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@adonisjs/assembler": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/assembler/-/assembler-7.8.2.tgz",
-      "integrity": "sha512-csLdMW58cwuRjdPEDE0dqwHZCT5snCh+1sQ19HPnQ/BLKPPAvQdDRdw0atoC8LVmouB8ghXVHp3SxnVxlvXYWQ==",
+    "node_modules/@adonisjs/application/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@adonisjs/env": "^6.1.0",
-        "@antfu/install-pkg": "^0.4.1",
-        "@poppinss/chokidar-ts": "^4.1.4",
-        "@poppinss/cliui": "^6.4.1",
-        "@poppinss/hooks": "^7.2.3",
-        "@poppinss/utils": "^6.7.3",
-        "cpy": "^11.1.0",
-        "dedent": "^1.5.3",
-        "execa": "^9.3.1",
-        "fast-glob": "^3.3.2",
-        "get-port": "^7.1.0",
-        "junk": "^4.0.1",
-        "picomatch": "^4.0.2",
-        "pretty-hrtime": "^1.0.3",
-        "slash": "^5.1.0",
-        "ts-morph": "^23.0.0"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.0.0 || ^5.0.0"
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
       }
     },
     "node_modules/@adonisjs/auth": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/auth/-/auth-9.6.0.tgz",
-      "integrity": "sha512-v7wHlY606TwqnWWU5SIMJV0ZcNhjH2LeBLb764eCFVgeNEEdv8konhRcABqTTNADrHr1ANVuV7PymN9gzgG63w==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/auth/-/auth-10.1.0.tgz",
+      "integrity": "sha512-H92C4HLWBpvxtQrgnsdWdWfoGu2bM/j+nyk/tHmpxH9ETkNOH0z3dRfEebLJI63vtTDpRp5cwiI0bzn32gUQiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@adonisjs/presets": "^2.6.4",
-        "@poppinss/utils": "^6.10.1",
+        "@adonisjs/presets": "^3.0.0",
         "basic-auth": "^2.0.1"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/core": "^6.11.0",
-        "@adonisjs/lucid": "^20.0.0 || ^21.0.1",
-        "@adonisjs/session": "^7.4.1",
-        "@japa/api-client": "^2.0.3 || ^3.0.0",
-        "@japa/browser-client": "^2.0.3",
-        "@japa/plugin-adonisjs": "^3.0.1 || ^4.0.0"
+        "@adonisjs/assembler": "^8.0.0-next.26 || ^8.0.0",
+        "@adonisjs/core": "^7.0.0-next.16 || ^7.0.0",
+        "@adonisjs/i18n": "^3.0.0-next.2 || ^3.0.0",
+        "@adonisjs/lucid": "^22.0.0-next.1 || ^22.0.0",
+        "@adonisjs/session": "^8.0.0-next.1 || ^8.0.0",
+        "@japa/api-client": "^3.1.1",
+        "@japa/browser-client": "^2.2.0",
+        "@japa/plugin-adonisjs": "^5.1.0-next.0 || ^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@adonisjs/assembler": {
+          "optional": true
+        },
+        "@adonisjs/i18n": {
+          "optional": true
+        },
         "@adonisjs/lucid": {
           "optional": true
         },
@@ -177,48 +190,60 @@
       }
     },
     "node_modules/@adonisjs/bodyparser": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@adonisjs/bodyparser/-/bodyparser-10.1.3.tgz",
-      "integrity": "sha512-FtxUbVYDHrW94z4+w1dOTq31TLkD3wAoyVVCQLY9irNOBrjSH9ucKP4tq8tq2jeQffoRh3R2j7jp2VW8psSQcA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@adonisjs/bodyparser/-/bodyparser-11.0.1.tgz",
+      "integrity": "sha512-RUpkRRSvCSMLmVJcYUyaAwC9Z1tWlThBvVGiIU5bkWwwe5CcbG2f9sifzod04B+hcgJ4xWSs+FF/WNdbwWFwhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@paralleldrive/cuid2": "^2.2.2",
         "@poppinss/macroable": "^1.1.0",
-        "@poppinss/multiparty": "^2.0.1",
-        "@poppinss/utils": "^6.10.1",
-        "@types/qs": "^6.14.0",
-        "bytes": "^3.1.2",
-        "file-type": "^21.1.1",
+        "@poppinss/middleware": "^3.2.7",
+        "@poppinss/multiparty": "^3.0.0",
+        "@poppinss/qs": "^6.15.0",
+        "@poppinss/utils": "^7.0.0",
+        "file-type": "^21.3.0",
         "inflation": "^2.1.0",
         "media-typer": "^1.1.0",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.1"
+        "raw-body": "^3.0.2"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/http-server": "^7.4.0"
+        "@adonisjs/http-server": "^8.0.0-next.17 || ^8.0.0"
+      }
+    },
+    "node_modules/@adonisjs/bodyparser/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
       }
     },
     "node_modules/@adonisjs/cache": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@adonisjs/cache/-/cache-1.3.1.tgz",
-      "integrity": "sha512-A1C7KEop4rFo4cOmzrldpw8EAoHe6zVoJYVGgKbt2dEGGxZcRshpSnRcdYWTC2SFa4fjdx20bPr8yN30xAQFTw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/cache/-/cache-2.1.0.tgz",
+      "integrity": "sha512-rrdpJ10zF+6IWfAjz6wj1dBqPrtzk3q53ezsm+sYymNeG8C31Cj5FvwdbbhcXoQvR/SLOEi6SONtDxHK/D8doA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bentocache": "^1.5.0"
+        "bentocache": "^1.6.1"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/assembler": "^7.0.0",
-        "@adonisjs/core": "^6.2.0",
-        "@adonisjs/lucid": "^20.0.0 || ^21.0.0",
-        "@adonisjs/redis": "^8.0.0 || ^9.0.0"
+        "@adonisjs/assembler": "^8.0.0-next.19",
+        "@adonisjs/core": "^7.0.0-next.13",
+        "@adonisjs/lucid": "^22.0.0-next.1",
+        "@adonisjs/redis": "^10.0.0-next.1"
       },
       "peerDependenciesMeta": {
         "@adonisjs/lucid": {
@@ -230,66 +255,78 @@
       }
     },
     "node_modules/@adonisjs/config": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@adonisjs/config/-/config-5.0.3.tgz",
-      "integrity": "sha512-dO7gkYxZsrsnR8n7d5KUpyi+Q5c6BnV2rmFDqEmEjz5AkOZLLzJJJbeHgMb+M27le7ifEUoa8MRu6RED8NMsJg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/config/-/config-6.1.0.tgz",
+      "integrity": "sha512-YVDRL8xHCtM6iMnAefOBaz6iXVpojwBPDQWPKxnVSucycYeNGrGitJiLy+cGaeAU7Gjm8al9SJRJt3rRPr5PKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/utils": "^6.9.4"
+        "@poppinss/utils": "^7.0.0"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@adonisjs/config/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
       }
     },
     "node_modules/@adonisjs/core": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/core/-/core-6.20.0.tgz",
-      "integrity": "sha512-2DpPlQALzPScD5yzDJ4O7ZyzUt3tqHj4zjQDcO2CifhvOnli9tw0xsJpmPVbnogu1Z//N0YB1esOCD7JPmWLxg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@adonisjs/core/-/core-7.3.2.tgz",
+      "integrity": "sha512-rwF9Cdw2CCFODeWUfCb4wjeuQOZIy7Bma1NYA769kVCXyMYoA/QIp86V8PmpwBabdoK4M+JitXgWwAzB9eInGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@adonisjs/ace": "^13.4.0",
-        "@adonisjs/application": "^8.4.2",
-        "@adonisjs/bodyparser": "^10.1.3",
-        "@adonisjs/config": "^5.0.3",
-        "@adonisjs/encryption": "^6.0.2",
-        "@adonisjs/env": "^6.2.0",
-        "@adonisjs/events": "^9.0.2",
-        "@adonisjs/fold": "^10.2.1",
-        "@adonisjs/hash": "^9.1.1",
-        "@adonisjs/health": "^2.0.0",
-        "@adonisjs/http-server": "^7.8.0",
-        "@adonisjs/logger": "^6.0.7",
-        "@adonisjs/repl": "^4.1.2",
-        "@antfu/install-pkg": "^1.1.0",
-        "@paralleldrive/cuid2": "^2.3.1",
+        "@adonisjs/ace": "^14.1.0",
+        "@adonisjs/application": "^9.0.0",
+        "@adonisjs/bodyparser": "^11.0.1",
+        "@adonisjs/config": "^6.1.0",
+        "@adonisjs/env": "^7.0.0",
+        "@adonisjs/events": "^10.2.0",
+        "@adonisjs/fold": "^11.0.0",
+        "@adonisjs/hash": "^10.1.0",
+        "@adonisjs/health": "^3.1.0",
+        "@adonisjs/http-server": "^8.2.0",
+        "@adonisjs/http-transformers": "^2.3.1",
+        "@adonisjs/logger": "^7.1.1",
+        "@adonisjs/repl": "^5.0.0",
+        "@boringnode/encryption": "^1.0.0",
         "@poppinss/colors": "^4.1.6",
-        "@poppinss/dumper": "^0.6.5",
-        "@poppinss/macroable": "^1.1.0",
-        "@poppinss/utils": "^6.10.1",
-        "@sindresorhus/is": "^7.2.0",
+        "@poppinss/dumper": "^0.7.0",
+        "@poppinss/macroable": "^1.1.2",
+        "@poppinss/utils": "^7.0.1",
+        "@sindresorhus/is": "^8.0.0",
         "@types/he": "^1.2.3",
         "error-stack-parser-es": "^1.0.5",
         "he": "^1.2.0",
-        "parse-imports": "^2.2.1",
         "pretty-hrtime": "^1.0.3",
-        "string-width": "^7.2.0",
-        "youch": "^3.3.4",
-        "youch-terminal": "^2.2.3"
+        "string-width": "^8.2.0"
       },
       "bin": {
         "adonis-kit": "build/toolkit/main.js"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/assembler": "^7.8.0",
-        "@vinejs/vine": "^2.1.0 || ^3.0.0 || ^4.0.0",
-        "argon2": "^0.31.2 || ^0.41.0 || ^0.43.0 || ^0.44.0",
-        "bcrypt": "^5.1.1 || ^6.0.0",
-        "edge.js": "^6.2.0"
+        "@adonisjs/assembler": "^8.0.0-next.23 || ^8.0.0",
+        "@vinejs/vine": "^4.0.0",
+        "argon2": "^0.44.0",
+        "bcrypt": "^6.0.0",
+        "edge.js": "^6.2.0",
+        "pino-pretty": "^13.1.3",
+        "youch": "^4.1.0-beta.13 || ^4.1.0"
       },
       "peerDependenciesMeta": {
         "@adonisjs/assembler": {
@@ -306,59 +343,81 @@
         },
         "edge.js": {
           "optional": true
+        },
+        "pino-pretty": {
+          "optional": true
+        },
+        "youch": {
+          "optional": true
         }
       }
     },
-    "node_modules/@adonisjs/core/node_modules/@antfu/install-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
-      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+    "node_modules/@adonisjs/core/node_modules/@adonisjs/env": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/env/-/env-7.0.0.tgz",
+      "integrity": "sha512-9lSGONI4B1E7LxyVZiUd1yCH9BOri4Ybp4b9x3ojT9AkKfYwqvj4S2USIvFAlkE7eHUC2WMvPgMLX17342Y3ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "package-manager-detector": "^1.3.0",
-        "tinyexec": "^1.0.1"
+        "@poppinss/utils": "^7.0.0",
+        "@poppinss/validator-lite": "^2.1.2",
+        "split-lines": "^3.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
-    "node_modules/@adonisjs/core/node_modules/package-manager-detector": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+    "node_modules/@adonisjs/core/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
+      }
     },
-    "node_modules/@adonisjs/core/node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+    "node_modules/@adonisjs/core/node_modules/@sindresorhus/is": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.0.0.tgz",
+      "integrity": "sha512-YvOsokBE5NsyHuXMnwEVB7lgFk6lX8F4OXCruYVgFII0hUHof0RGUvhMoabVt9hRqbg+qVzayzEG24RCcxcYeA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@adonisjs/drive": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@adonisjs/drive/-/drive-3.4.1.tgz",
-      "integrity": "sha512-oDYY4wJ7wDMlO4E+dZPYBu+T3Av7Mj+JL8+J33qgyxtiJylnZgoZDuRfFjZZix/bFNNuWX2sLwTMnyiDcK+YsA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/drive/-/drive-4.0.0.tgz",
+      "integrity": "sha512-dJPmTKmYba05/e6x807VjL9m5JT56bZKqAgFknkS96kUSH52i9M+InsZTwUQ87cW9UQ1tED8ts++LgsyE3EkEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flydrive": "^1.1.0"
+        "flydrive": "^2.0.0"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/core": "^6.2.0",
-        "@aws-sdk/client-s3": "^3.577.0",
-        "@aws-sdk/s3-request-presigner": "^3.577.0",
-        "@google-cloud/storage": "^7.10.2"
+        "@adonisjs/assembler": "^8.0.0-next.7 || ^8.0.0",
+        "@adonisjs/core": "^7.0.0-next.0 || ^7.0.0",
+        "@aws-sdk/client-s3": "^3.884.0",
+        "@aws-sdk/s3-request-presigner": "^3.884.0",
+        "@google-cloud/storage": "^7.17.0",
+        "edge.js": "^6.4.0"
       },
       "peerDependenciesMeta": {
+        "@adonisjs/assembler": {
+          "optional": true
+        },
         "@aws-sdk/client-s3": {
           "optional": true
         },
@@ -367,36 +426,10 @@
         },
         "@google-cloud/storage": {
           "optional": true
+        },
+        "edge.js": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/@adonisjs/encryption": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/encryption/-/encryption-6.0.2.tgz",
-      "integrity": "sha512-37XqVPsZi6zXMbC0Me1/qlcTP0uE+KAtYOFx7D7Tvtz377NL/6gqxqgpW/BopgOSD+CVDXjzO/Wx3M2UrbkJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/utils": "^6.7.3"
-      },
-      "engines": {
-        "node": ">=18.16.0"
-      }
-    },
-    "node_modules/@adonisjs/env": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/env/-/env-6.2.0.tgz",
-      "integrity": "sha512-DZ7zQ4sBhzWftjU/SxJ7BstimrEiByCvmtAcMNDpDjOtJnR50172PRz1X7KjM3EqjCVrB19izzRVx/rmpCRPOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/utils": "^6.9.2",
-        "@poppinss/validator-lite": "^2.1.0",
-        "dotenv": "^16.4.7",
-        "split-lines": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.16.0"
       }
     },
     "node_modules/@adonisjs/eslint-config": {
@@ -437,55 +470,56 @@
       }
     },
     "node_modules/@adonisjs/events": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/events/-/events-9.0.2.tgz",
-      "integrity": "sha512-qZn2e9V9C8tF4MNqEWv5JGxMG7gcHSJM8RncGpjuJ4cwFwd2jF4xrN6wkCprTVwoyZSxNS0Cp9NkAonySjG5vg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/events/-/events-10.2.0.tgz",
+      "integrity": "sha512-SzwzbmTLsybSZd47zZMZ3df7puwhY7D8vZ5Uy79SiHjLKbr2eVzUuKjjoYB6/0pZu6IwK9Qx06dI43sl+tLoDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/utils": "^6.7.3",
-        "@sindresorhus/is": "^6.2.0",
-        "emittery": "^1.0.3"
+        "@poppinss/utils": "^7.0.0",
+        "@sindresorhus/is": "^7.2.0",
+        "emittery": "^1.2.0"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/application": "^8.0.2",
-        "@adonisjs/fold": "^10.0.1"
+        "@adonisjs/application": "^9.0.0-next.14 || ^9.0.0",
+        "@adonisjs/fold": "^11.0.0-next.4 || ^11.0.0"
       }
     },
-    "node_modules/@adonisjs/events/node_modules/@sindresorhus/is": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.3.1.tgz",
-      "integrity": "sha512-FX4MfcifwJyFOI2lPoX7PQxCqx8BG1HCho7WdiXwpEQx1Ycij0JxkfYtGK7yqNScrZGSlt6RE6sw8QYoH7eKnQ==",
+    "node_modules/@adonisjs/events/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
       }
     },
     "node_modules/@adonisjs/fold": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@adonisjs/fold/-/fold-10.2.1.tgz",
-      "integrity": "sha512-WuW62T3jZB0w/7C7YbDkfzIMJaEQZ2cGdf6qoeevB0zYNH4kTp2oREfTx45ndNjiN6D5GhjoR8JRpjiAfppFIA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/fold/-/fold-11.0.0.tgz",
+      "integrity": "sha512-RnmDPWz2imVp/B74xitxCPqTdoP07bZvfJe1bh9CD9Rmia4jjDvehZF67KFyGNMZ24MuKasqs3jOcM1vGJp0GA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/utils": "^7.0.0-next.3",
-        "parse-imports": "^2.2.1"
+        "@poppinss/utils": "^7.0.0",
+        "parse-imports": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@adonisjs/fold/node_modules/@poppinss/utils": {
-      "version": "7.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.0-next.7.tgz",
-      "integrity": "sha512-Jwc6YqiLf8wAarEpC2bzamq5XIe3i553LeCzZhqYamSK1zZjYoa6tEPjKq1ASARjuNpYQAj96TLBw/yXJJDF/A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -497,20 +531,20 @@
       }
     },
     "node_modules/@adonisjs/hash": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@adonisjs/hash/-/hash-9.1.1.tgz",
-      "integrity": "sha512-ZkRguwjAp4skKvKDdRAfdJ2oqQ0N7p9l3sioyXO1E8o0WcsyDgEpsTQtuVNoIdMiw4sn4gJlmL3nyF4BcK1ZDQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/hash/-/hash-10.1.0.tgz",
+      "integrity": "sha512-lW0lGwpscu9PUo3Sb3PF580jYU29I9wsPn3dIKzZbTVedqkpaNpBK3YKedwZYkDpYmiyYXi08eTTNhdWjiGLQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@phc/format": "^1.0.0",
-        "@poppinss/utils": "^6.9.3"
+        "@poppinss/utils": "^7.0.0"
       },
       "engines": {
         "node": ">=20.6.0"
       },
       "peerDependencies": {
-        "argon2": "^0.31.2 || ^0.41.0 || ^0.43.0",
+        "argon2": "^0.31.2 || ^0.41.0 || ^0.43.0 || ^0.44.0",
         "bcrypt": "^5.1.1 || ^6.0.0"
       },
       "peerDependenciesMeta": {
@@ -522,135 +556,258 @@
         }
       }
     },
-    "node_modules/@adonisjs/health": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/health/-/health-2.0.0.tgz",
-      "integrity": "sha512-dEAABiAJew1imzwi+OvV/SAnjkMp8TbD5ZIzx1dMRnPynJAlRf37//bHLwZ5Cw44ke5kPzZ/l1n9cx/VeBCicA==",
+    "node_modules/@adonisjs/hash/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/utils": "^6.7.3",
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
+      }
+    },
+    "node_modules/@adonisjs/health": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/health/-/health-3.1.0.tgz",
+      "integrity": "sha512-m3doBnSwi/l9v1DO79xmjAoSPl9b2XCp+crGwF8QUlhe5CgWgtfnL0SeFNEiZGliD3c4gYdihKz4Pnydctva8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/utils": "^7.0.0",
         "check-disk-space": "^3.4.0"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=24.0.0"
       }
     },
-    "node_modules/@adonisjs/http-server": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/http-server/-/http-server-7.8.0.tgz",
-      "integrity": "sha512-aVMOpExPDNwxjnKGnc4g4sJTIQC3CfNwzWfPFWJm4WnAGXxdI3OxI2zU9FTopB50y0OVK3dWO4/c1Fu6U4vjWQ==",
+    "node_modules/@adonisjs/health/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@paralleldrive/cuid2": "^2.2.2",
-        "@poppinss/macroable": "^1.0.4",
-        "@poppinss/matchit": "^3.1.2",
-        "@poppinss/middleware": "^3.2.5",
-        "@poppinss/utils": "^6.10.0",
-        "@sindresorhus/is": "^7.0.2",
-        "accepts": "^1.3.8",
-        "content-disposition": "^0.5.4",
-        "cookie": "^1.0.2",
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
+      }
+    },
+    "node_modules/@adonisjs/http-server": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/http-server/-/http-server-8.2.0.tgz",
+      "integrity": "sha512-rqrvPd5RclMB4ubLN85Mj2zl/zFmDl2M1MIjCEbjh0R9iyaVNEvMX0R6FEPmZxxnz4EKAmN3zffHlB0p8j5e1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/macroable": "^1.1.2",
+        "@poppinss/matchit": "^3.2.0",
+        "@poppinss/middleware": "^3.2.7",
+        "@poppinss/qs": "^6.15.0",
+        "@poppinss/utils": "^7.0.1",
+        "@sindresorhus/is": "^7.2.0",
+        "content-disposition": "^1.1.0",
+        "cookie-es": "^3.1.1",
         "destroy": "^1.2.0",
         "encodeurl": "^2.0.0",
         "etag": "^1.8.1",
         "fresh": "^0.5.2",
-        "mime-types": "^3.0.1",
+        "mime-types": "^3.0.2",
         "on-finished": "^2.4.1",
         "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
         "tmp-cache": "^1.1.0",
         "type-is": "^2.0.1",
-        "vary": "^1.1.2",
-        "youch": "^3.3.4"
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/application": "^8.0.2",
-        "@adonisjs/encryption": "^6.0.0",
-        "@adonisjs/events": "^9.0.0",
-        "@adonisjs/fold": "^10.0.1",
-        "@adonisjs/logger": "^6.0.1"
-      }
-    },
-    "node_modules/@adonisjs/inertia": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@adonisjs/inertia/-/inertia-1.2.4.tgz",
-      "integrity": "sha512-brYEkXn7ZNv394Bvqewlh9anoxLnW8yQ8beyJz14I4ylZmEyyOcxis3JpobpUzlpWHGLAU/zssEqpJL5AXFcmg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/utils": "^6.8.3",
-        "@tuyau/utils": "^0.0.4",
-        "crc-32": "^1.2.2",
-        "edge-error": "^4.0.1",
-        "html-entities": "^2.5.2",
-        "locate-path": "^7.2.0",
-        "qs": "^6.13.0"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "peerDependencies": {
-        "@adonisjs/core": "^6.9.1",
-        "@adonisjs/session": "^7.4.0",
-        "@adonisjs/vite": "^3.0.0",
-        "@japa/api-client": "^2.0.0",
-        "edge.js": "^6.0.0"
+        "@adonisjs/application": "^9.0.0-next.14 || ^9.0.0",
+        "@adonisjs/events": "^10.1.0-next.4 || ^10.1.0",
+        "@adonisjs/fold": "^11.0.0-next.4 || ^11.0.0",
+        "@adonisjs/logger": "^7.1.0-next.3 || ^7.1.0",
+        "@boringnode/encryption": "^0.2.0 || ^1.0.0",
+        "youch": "^4.1.0-beta.13 || ^4.1.0"
       },
       "peerDependenciesMeta": {
-        "@japa/api-client": {
+        "youch": {
           "optional": true
         }
       }
     },
-    "node_modules/@adonisjs/logger": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@adonisjs/logger/-/logger-6.0.7.tgz",
-      "integrity": "sha512-zeWk14EuFGD+YrwLfwrzUcEKS06equr1Xn624+b28H3s0JhjmgXNfsDRlBe9X+GgJiuD8Zf3/52MX//7cGaNWQ==",
+    "node_modules/@adonisjs/http-server/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/utils": "^6.10.1",
-        "abstract-logging": "^2.0.1",
-        "pino": "^10.1.0"
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
+      }
+    },
+    "node_modules/@adonisjs/http-transformers": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@adonisjs/http-transformers/-/http-transformers-2.3.1.tgz",
+      "integrity": "sha512-N3gBcKyoPHDeVvVIedTzc+ARSUURwNGTPid/e3iLdM4v/myoSnXd76FL/GGzMmjfqqxegpjI2IEMibG7ylrKSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/types": "^1.2.1"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
+      },
+      "peerDependencies": {
+        "@adonisjs/fold": "^11.0.0-next.2"
+      }
+    },
+    "node_modules/@adonisjs/inertia": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/inertia/-/inertia-4.2.0.tgz",
+      "integrity": "sha512-AL5IWsoA/qf34AMHf3H+YQydm9v7pj3daOeWLuRn6FxwSkald1zEo5lS7aBD4Nbsn3fJKPKvBlO9BSeIAw1FYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/utils": "^7.0.0",
+        "edge-error": "^4.0.2",
+        "html-entities": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      },
+      "peerDependencies": {
+        "@adonisjs/assembler": "^8.0.0-next.29 || ^8.0.0",
+        "@adonisjs/core": "^7.0.0-next.23 || ^7.0.0",
+        "@adonisjs/session": "^8.0.0-next.2 || ^8.0.0",
+        "@adonisjs/vite": "^5.1.0-next.2 || ^5.1.0",
+        "@inertiajs/react": "^2.3.8",
+        "@inertiajs/vue3": "^2.3.8",
+        "@japa/api-client": "^3.1.1",
+        "@japa/plugin-adonisjs": "^5.1.0-next.1 || ^5.1.0",
+        "@tuyau/core": "^1.0.0-beta.10 || ^1.0.0",
+        "edge.js": "^6.4.0",
+        "react": "^19.2.3",
+        "vue": "^3.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@adonisjs/assembler": {
+          "optional": true
+        },
+        "@inertiajs/react": {
+          "optional": true
+        },
+        "@inertiajs/vue3": {
+          "optional": true
+        },
+        "@japa/api-client": {
+          "optional": true
+        },
+        "@japa/plugin-adonisjs": {
+          "optional": true
+        },
+        "@tuyau/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adonisjs/inertia/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
+      }
+    },
+    "node_modules/@adonisjs/logger": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@adonisjs/logger/-/logger-7.1.1.tgz",
+      "integrity": "sha512-MmUlp8xBMT6zZy0+vnQcQjHIlNfU4pUJARlINr7Bqha9BvhIn03QZgJL5QJ+kJe1tl6ZpNAryoRTJUiOk/wINQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/utils": "^7.0.0",
+        "abstract-logging": "^2.0.1",
+        "pino": "^10.3.1"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      },
+      "peerDependencies": {
+        "pino-pretty": "^13.1.1"
+      },
+      "peerDependenciesMeta": {
+        "pino-pretty": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adonisjs/logger/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
       }
     },
     "node_modules/@adonisjs/lucid": {
-      "version": "21.8.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/lucid/-/lucid-21.8.2.tgz",
-      "integrity": "sha512-+ocmllAr77cc7EgQoDQokNpB3lz1Rmw0olcNtx7TbR8TeCAiegDAkNe1HylKzNOGX+i0kvb0FeOvSlZ9N0GmXQ==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/@adonisjs/lucid/-/lucid-22.4.2.tgz",
+      "integrity": "sha512-3ztENqBQIFSGAWREHKCGbL1g4ehtsxxsuFX72Uf5bq+oSc0D6UcumjzYpU8TPyBxhmgS6HuRSfz2rG42iuz7AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@adonisjs/presets": "^2.6.4",
-        "@faker-js/faker": "^9.9.0",
+        "@adonisjs/presets": "^3.0.0",
+        "@faker-js/faker": "^10.4.0",
         "@poppinss/hooks": "^7.3.0",
-        "@poppinss/macroable": "^1.1.0",
-        "@poppinss/utils": "^6.10.1",
+        "@poppinss/macroable": "^1.1.2",
+        "@poppinss/qs": "^6.15.0",
+        "@poppinss/utils": "^7.0.1",
+        "deepmerge": "^4.3.1",
         "fast-deep-equal": "^3.1.3",
         "igniculus": "^1.5.0",
         "kleur": "^4.1.5",
-        "knex": "^3.1.0",
-        "knex-dynamic-connection": "^3.2.0",
+        "knex": "^3.2.8",
+        "knex-dynamic-connection": "^5.0.1",
         "pretty-hrtime": "^1.0.3",
-        "qs": "^6.14.1",
         "slash": "^5.1.0",
         "tarn": "^3.0.2"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/assembler": "^7.7.0",
-        "@adonisjs/core": "^6.10.1",
-        "@vinejs/vine": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "@adonisjs/assembler": "^8.0.0-next.29 || ^8.0.0",
+        "@adonisjs/core": "^7.0.0-next.21 || ^7.0.0",
+        "@vinejs/vine": "^3.0.0 || ^4.0.0",
         "luxon": "^3.4.4"
       },
       "peerDependenciesMeta": {
@@ -665,49 +822,72 @@
         }
       }
     },
-    "node_modules/@adonisjs/mail": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/mail/-/mail-9.2.2.tgz",
-      "integrity": "sha512-gf/r10SjyoX9L37QiEZG+ueh8fp4XA57yH+NKiHpqWTNMdUl3d+f3HlNG7xlFmESgahgPR+iDusZ2zZewAeJQw==",
+    "node_modules/@adonisjs/lucid/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/colors": "^4.1.2",
-        "@poppinss/macroable": "^1.0.1",
-        "@poppinss/utils": "^6.7.2",
-        "@types/nodemailer": "^6.4.14",
-        "fastq": "^1.17.1",
-        "formdata-node": "^6.0.3",
-        "got": "^14.2.1",
-        "ical-generator": "^7.0.0",
-        "nodemailer": "^6.9.13"
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
+      }
+    },
+    "node_modules/@adonisjs/mail": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/mail/-/mail-10.2.0.tgz",
+      "integrity": "sha512-MsFPHkms9vFH66Dd25IlRALhRMq/FdzaA93xK+QAKSXVd8B6Trotrq86BjeLEbaa85WuL+6Z6OFjXFj2tcmJIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/macroable": "^1.1.0",
+        "@poppinss/object-builder": "^1.1.0",
+        "@types/nodemailer": "^7.0.11",
+        "fastq": "^1.20.1",
+        "ical-generator": "^10.0.0",
+        "ky": "^1.14.3",
+        "nodemailer": "^8.0.1"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/core": "^6.2.0",
-        "@aws-sdk/client-ses": "^3.485.0",
-        "edge.js": "^6.0.1"
+        "@adonisjs/assembler": "^8.0.0-next.14 || ^8.0.0",
+        "@adonisjs/core": "^7.0.0-next.8 || ^7.0.0",
+        "@aws-sdk/client-sesv2": "^3.997.0",
+        "edge.js": "^6.0.1",
+        "mjml": "^4.18.0"
       },
       "peerDependenciesMeta": {
-        "@aws-sdk/client-ses": {
+        "@adonisjs/assembler": {
+          "optional": true
+        },
+        "@aws-sdk/client-sesv2": {
+          "optional": true
+        },
+        "edge.js": {
+          "optional": true
+        },
+        "mjml": {
           "optional": true
         }
       }
     },
     "node_modules/@adonisjs/presets": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@adonisjs/presets/-/presets-2.6.4.tgz",
-      "integrity": "sha512-WvzWouziX88GMoGBLDobGRaSktWfz+fRqADJyhJd7+l0M2VMm5NF0LvAXbV8lMBLtBCicOxk973bJ9Kmyfy3qQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/presets/-/presets-3.0.0.tgz",
+      "integrity": "sha512-+gVIvyEiM7jiN5Gb93200TAC8ed3vZIPfxFFo0pIVgX8k40BleuYhWxFhI6TPocVXXIIpw2JuMFV2Pqjk36W2A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@poppinss/utils": "^6.7.3"
+      "engines": {
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/assembler": "^7.8.2",
-        "@adonisjs/core": "^6.13.0"
+        "@adonisjs/assembler": "^8.0.0-next.9 || ^8.0.0",
+        "@adonisjs/core": "^7.0.0-next.1 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "@adonisjs/assembler": {
@@ -726,43 +906,48 @@
       }
     },
     "node_modules/@adonisjs/repl": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/repl/-/repl-4.1.2.tgz",
-      "integrity": "sha512-NnczRJusl0082GOjEFYwObW/yBGJtpfJFnkFCQdQ6eykgBHVNYaY6qstfob+l1bedetRj0hrDY6YfsWMkA0MCg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/repl/-/repl-5.0.0.tgz",
+      "integrity": "sha512-cPp0w5svYUA3M1gdxQBO2Mx5g+SZfPweqKCAxk7C1Os/Qu67JKgWqXqNnl1q0Tzv/l0L19Ms1C7ivzQxeBNajg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/colors": "^4.1.5",
-        "string-width": "^7.2.0"
+        "@poppinss/colors": "^4.1.6",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@adonisjs/session": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/session/-/session-7.6.0.tgz",
-      "integrity": "sha512-EuOcwWPUoFB9OQmENwv4GpAaczyAT8kDS+HAFse/Yz2VTjY1KxzmTfcmLIGkAxN9lU3h5TwoHKgVXLF373ORUQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/session/-/session-8.1.0.tgz",
+      "integrity": "sha512-hTd5m49Ro8XhxVQN0yyCeDOihDhj+mFIVltzeWPXkCxK19JHAtA++TAygxSUEhvcm56IVS43XWNE1lNIOPjMJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@poppinss/macroable": "^1.0.4",
-        "@poppinss/utils": "^6.10.0"
+        "@poppinss/macroable": "^1.1.2",
+        "@poppinss/utils": "^7.0.1"
       },
       "engines": {
-        "node": ">=18.16.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/core": "^6.6.0",
-        "@adonisjs/lucid": "^21.0.0",
-        "@adonisjs/redis": "^8.0.1 || ^9.0.0",
-        "@aws-sdk/client-dynamodb": "^3.658.0",
-        "@aws-sdk/util-dynamodb": "^3.658.0",
-        "@japa/api-client": "^2.0.3 || ^3.0.0",
+        "@adonisjs/assembler": "^8.0.0-next.26 || ^8.0.0",
+        "@adonisjs/core": "^7.0.0-next.16 || ^7.0.0",
+        "@adonisjs/lucid": "^22.0.0-next.0 || ^22.0.0",
+        "@adonisjs/redis": "^10.0.0-next.2 || ^10.0.0",
+        "@aws-sdk/client-dynamodb": "^3.955.0",
+        "@aws-sdk/util-dynamodb": "^3.955.0",
+        "@japa/api-client": "^3.1.0",
         "@japa/browser-client": "^2.0.3",
-        "edge.js": "^6.0.2"
+        "@japa/plugin-adonisjs": "^5.1.0-next.0 || ^5.1.0",
+        "edge.js": "^6.4.0"
       },
       "peerDependenciesMeta": {
+        "@adonisjs/assembler": {
+          "optional": true
+        },
         "@adonisjs/lucid": {
           "optional": true
         },
@@ -781,51 +966,7 @@
         "@japa/browser-client": {
           "optional": true
         },
-        "edge.js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@adonisjs/transmit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/transmit/-/transmit-2.0.2.tgz",
-      "integrity": "sha512-Oyh4S1773N1Ams9mmFM2pplLx8R0IdYwqSTBLRgeDWaR+cyWrL9ZQvF2q7GqIjNzZsXuDgMdPuLlNo+69zIZIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@boringnode/transmit": "^0.2.1"
-      },
-      "engines": {
-        "node": ">=20.11.1"
-      },
-      "peerDependencies": {
-        "@adonisjs/core": "^6.2.0"
-      }
-    },
-    "node_modules/@adonisjs/vite": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/vite/-/vite-3.0.0.tgz",
-      "integrity": "sha512-E09M0zjGwu5GgMYFTGcA00f0y3DblvqekXgtxccjpOE/zLf5ggOxTwI5iZXgD4lVETYirQ0QdS3azznCW2TYkQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@poppinss/utils": "^6.7.3",
-        "@vavite/multibuild": "^4.1.1",
-        "edge-error": "^4.0.1",
-        "vite-plugin-restart": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "peerDependencies": {
-        "@adonisjs/core": "^6.3.0",
-        "@adonisjs/shield": "^8.0.0",
-        "edge.js": "^6.0.1",
-        "vite": "^5.1.4"
-      },
-      "peerDependenciesMeta": {
-        "@adonisjs/shield": {
+        "@japa/plugin-adonisjs": {
           "optional": true
         },
         "edge.js": {
@@ -833,19 +974,34 @@
         }
       }
     },
-    "node_modules/@antfu/install-pkg": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.4.1.tgz",
-      "integrity": "sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==",
+    "node_modules/@adonisjs/session/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "package-manager-detector": "^0.2.0",
-        "tinyexec": "^0.3.0"
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
+      }
+    },
+    "node_modules/@adonisjs/transmit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@adonisjs/transmit/-/transmit-3.0.1.tgz",
+      "integrity": "sha512-BbZTG+QuO/fLAHMBnqGhFjSJlzelqFmfVefpe3rK6mTDzH7wCIWae66BtwOMxCr/xUICza3sGkrv/aZP1MjDGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@boringnode/transmit": "^0.4.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "@adonisjs/core": "^7.0.0-next"
       }
     },
     "node_modules/@arr/every": {
@@ -884,9 +1040,9 @@
       }
     },
     "node_modules/@borewit/text-codec": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -945,43 +1101,47 @@
         "cuid2": "bin/cuid2.js"
       }
     },
-    "node_modules/@boringnode/transmit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@boringnode/transmit/-/transmit-0.2.2.tgz",
-      "integrity": "sha512-xIBg5PKqqgawNsXffq1P+BpRDjplfwOspwcFH5wfSN6uVcd5hYGC9lJpcXa1oL3wkQZimtiJhrTHhZZtgh2lqA==",
+    "node_modules/@boringnode/encryption": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@boringnode/encryption/-/encryption-1.0.0.tgz",
+      "integrity": "sha512-wGGOE7ywA4W6KAVoVC7s1P4ULzFLIQA/JvthGAa41EA0CaH7kGGawkBB5t5tvWopgBNMhOpIg3uxvULxqf2rQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@boringnode/bus": "^0.7.0",
-        "@poppinss/utils": "^6.8.3",
-        "emittery": "^1.0.3",
-        "matchit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=20.11.1"
-      }
-    },
-    "node_modules/@boringnode/transmit/node_modules/@boringnode/bus": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@boringnode/bus/-/bus-0.7.1.tgz",
-      "integrity": "sha512-F74H1XxpX0MSP2xfDv5cTuP9OgC4HHG+K2w8kNRj/k104D/aBMC7mcEcntgIZMX8QgcRQsREToP5kPH5kZOO/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@paralleldrive/cuid2": "^2.2.2",
-        "@poppinss/utils": "^6.9.2",
-        "object-hash": "^3.0.0"
+        "@poppinss/utils": "^7.0.0-next.7"
       },
       "engines": {
         "node": ">=20.6"
+      }
+    },
+    "node_modules/@boringnode/encryption/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
+      }
+    },
+    "node_modules/@boringnode/transmit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@boringnode/transmit/-/transmit-0.4.0.tgz",
+      "integrity": "sha512-pDOktrYglOLC7z8Nc5N6QAxSXHw/GSffwbr0Kzd0aDV62bNO85ZNOzZFiKG/VImnq4rU1nnXmrnLbtkRpmPhSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@boringnode/bus": "^0.9.0",
+        "@poppinss/utils": "^6.10.1",
+        "emittery": "^1.2.0",
+        "matchit": "^1.1.0"
       },
-      "peerDependencies": {
-        "ioredis": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ioredis": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=20.6"
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
@@ -1037,420 +1197,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@escalated-dev/plugin-sdk": {
@@ -1662,9 +1408,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
-      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
       "dev": true,
       "funding": [
         {
@@ -1674,8 +1420,8 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1748,52 +1494,6 @@
         "node": ">=24.0.0"
       }
     },
-    "node_modules/@japa/core/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@japa/core/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@japa/core/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/@japa/errors-printer": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@japa/errors-printer/-/errors-printer-4.1.4.tgz",
@@ -1808,18 +1508,6 @@
       },
       "engines": {
         "node": ">=18.16.0"
-      }
-    },
-    "node_modules/@japa/errors-printer/node_modules/@poppinss/dumper": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
-      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/colors": "^4.1.5",
-        "@sindresorhus/is": "^7.0.2",
-        "supports-color": "^10.0.0"
       }
     },
     "node_modules/@japa/errors-printer/node_modules/youch": {
@@ -1920,13 +1608,6 @@
         "url": "https://github.com/sponsors/Julien-R44"
       }
     },
-    "node_modules/@keyv/serialize": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
-      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -1935,70 +1616,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@paralleldrive/cuid2": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
-      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@phc/format": {
@@ -2031,87 +1648,22 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
-    "node_modules/@poppinss/chokidar-ts": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@poppinss/chokidar-ts/-/chokidar-ts-4.1.9.tgz",
-      "integrity": "sha512-Nl4JAb5dvwmZhXElSuiuHy4YkB7YFql/AE2tTu9TyJCfPnUrcwm2iMTUZVa+aGz+bolRPuPNKsuypxN59gBvQQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chokidar": "^4.0.3",
-        "emittery": "^1.1.0",
-        "memoize": "^10.1.0",
-        "picomatch": "^4.0.2",
-        "slash": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=18.16.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      }
-    },
     "node_modules/@poppinss/cliui": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@poppinss/cliui/-/cliui-6.7.0.tgz",
-      "integrity": "sha512-ihlhDUHw4Lfx6Euo8SSDar/rHHD8T1aFXJ1Z3NYSYjHcr9rSK5iy6zC5xvQJCeGY1BTninW520iKv/hd4lS0tA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/cliui/-/cliui-6.8.1.tgz",
+      "integrity": "sha512-o/ssbwr+r6woG65rk9eFHnn9dVUphZr/Rk+4+05ENVMBWYpYhTJGdE9RobTG5JLFubvO4gWIyFeNlC+I4EM6eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.6",
+        "cli-boxes": "^4.0.1",
         "cli-table3": "^0.6.5",
-        "cli-truncate": "^5.1.1",
-        "log-update": "^7.0.2",
+        "cli-truncate": "^5.2.0",
+        "log-update": "^7.2.0",
         "pretty-hrtime": "^1.0.3",
-        "string-width": "^8.1.0",
-        "supports-color": "^10.2.2"
-      }
-    },
-    "node_modules/@poppinss/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@poppinss/cliui/node_modules/string-width": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
-      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@poppinss/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "string-width": "^8.2.0",
+        "supports-color": "^10.2.2",
+        "terminal-size": "^4.0.1"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -2125,9 +1677,9 @@
       }
     },
     "node_modules/@poppinss/dumper": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
-      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2150,21 +1702,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@poppinss/inspect": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@poppinss/inspect/-/inspect-1.0.1.tgz",
-      "integrity": "sha512-kLeEaBSGhlleyYvKc7c9s3uE6xv7cwyulE0EgHf4jU/CL96h0yC4mkdw1wvC1l1PYYQozCGy46FwMBAAMOobCA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@poppinss/macroable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@poppinss/macroable/-/macroable-1.1.0.tgz",
-      "integrity": "sha512-y/YKzZDuG8XrpXpM7Z1RdQpiIc0MAKyva24Ux1PB4aI7RiSI/79K8JVDcdyubriTm7vJ1LhFs8CrZpmPnx/8Pw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@poppinss/macroable/-/macroable-1.1.2.tgz",
+      "integrity": "sha512-FAVBRzzWhYP5mA3lCwLH1A0fKBqq5anyjGet90Z81aRK5c/+LTGUE1zJhZrErjaenBSOOI9BVUs3WVmotneFQA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2186,15 +1727,13 @@
       "license": "MIT"
     },
     "node_modules/@poppinss/multiparty": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@poppinss/multiparty/-/multiparty-2.0.1.tgz",
-      "integrity": "sha512-Pf3V9PFyZDIkDBBiAOT2hdmA+1l/+hverHbUnMzNzwtwgO50s2ZPt5KxUydVA0hceg9gryo5unQ0WUF1SO9tkQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/multiparty/-/multiparty-3.0.0.tgz",
+      "integrity": "sha512-z9jchUzsv7E+7sa4tWHb0+95Byx7w0ydlPGxg3nzyb7h3QlRdeW8/QkU9SexUY4lsT12do93AfNBAhSuOoVqjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "http-errors": "^2.0.0",
-        "safe-buffer": "5.2.1",
-        "uid-safe": "2.1.5"
+        "http-errors": "^2.0.0"
       }
     },
     "node_modules/@poppinss/object-builder": {
@@ -2218,6 +1757,19 @@
         "@poppinss/exception": "^1.2.2",
         "@poppinss/object-builder": "^1.1.0",
         "enquirer": "^2.4.1"
+      }
+    },
+    "node_modules/@poppinss/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-QzfMhxrRB5EPeGz0l8hTwKZ5dFX6ed0aETGbuD369StCO8Ad3SW4wWBYamOK5IKeM/dfOeKaCwUZPTnGcj+jKg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@poppinss/string": {
@@ -2265,388 +1817,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -2665,20 +1835,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@speed-highlight/core": {
@@ -2734,27 +1890,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@ts-morph/common": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.24.0.tgz",
-      "integrity": "sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-glob": "^3.3.2",
-        "minimatch": "^9.0.4",
-        "mkdirp": "^3.0.1",
-        "path-browserify": "^1.0.1"
-      }
-    },
-    "node_modules/@tuyau/utils": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@tuyau/utils/-/utils-0.0.4.tgz",
-      "integrity": "sha512-ex6CAJNLiTuOvx7nUrgs8FwNG/t88Mi8QTLSO3muHbB6vBSpYimZ6iSUkk4cjEFd4XDy0y+24GDgXKoBfGf4ag==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@types/adm-zip": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
@@ -2776,13 +1911,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
       "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2811,9 +1939,9 @@
       }
     },
     "node_modules/@types/nodemailer": {
-      "version": "6.4.22",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.22.tgz",
-      "integrity": "sha512-HV16KRsW7UyZBITE07B62k8PRAKFqRSFXn1T7vslurVjN761tMDBhk5Lbt17ehyTzK6XcyJnAgUpevrvkcVOzw==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2831,13 +1959,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
       "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3113,41 +2234,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@vavite/multibuild": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vavite/multibuild/-/multibuild-4.1.3.tgz",
-      "integrity": "sha512-V+6mskWf4GMQVb53w2fdJ5aR+zVkzpuCE9q3lDDo0v8AHjQApOeXydj/5rTERIFkO46yNHmr3insg2I/tC0TtA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "^18.19.50",
-        "cac": "^6.7.14",
-        "picocolors": "^1.1.0"
-      },
-      "peerDependencies": {
-        "vite": "^2.8.1 || 3 || 4 || 5"
-      }
-    },
-    "node_modules/@vavite/multibuild/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@vavite/multibuild/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -3163,43 +2249,6 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -3309,27 +2358,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
-    },
-    "node_modules/as-table": {
-      "version": "1.0.55",
-      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
-      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "printable-characters": "^1.0.42"
-      }
-    },
-    "node_modules/astring": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
-      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "astring": "bin/astring"
-      }
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -3450,17 +2478,6 @@
         "node": "*"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -3521,19 +2538,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/byte-counter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
-      "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3542,77 +2546,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "13.0.18",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.18.tgz",
-      "integrity": "sha512-rFWadDRKJs3s2eYdXlGggnBZKG7MTblkFBB0YllFds+UYnfogDp2wcR6JN97FhRkHTvq59n2vhNoHNZn29dh/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "^4.0.4",
-        "get-stream": "^9.0.1",
-        "http-cache-semantics": "^4.2.0",
-        "keyv": "^5.5.5",
-        "mimic-response": "^4.0.0",
-        "normalize-url": "^8.1.1",
-        "responselike": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3721,23 +2654,6 @@
         "lodash-es": "4.17.23"
       }
     },
-    "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -3775,6 +2691,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
+      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20 <19 || >=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -3842,14 +2771,14 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^7.1.0",
-        "string-width": "^8.0.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
         "node": ">=20"
@@ -3857,60 +2786,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
-      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/code-block-writer": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
-      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3964,16 +2839,17 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -3986,44 +2862,12 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cookie-es": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
       "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/copy-file": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/copy-file/-/copy-file-11.1.0.tgz",
-      "integrity": "sha512-X8XDzyvYaA6msMyAM575CUoygY5b44QzLcGRKsK3MFmXcOvQa518dNPLsKYwkYsn72g3EiW+LE0ytd/FlqWmyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.11",
-        "p-event": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -4037,41 +2881,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/cpy": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/cpy/-/cpy-11.1.0.tgz",
-      "integrity": "sha512-QGHetPSSuprVs+lJmMDcivvrBwTKASzXQ5qxFvRC2RFESjjod71bDvFvhxTjDgkNjrrb72AI6JPjfYwxrIy33A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "copy-file": "^11.0.0",
-        "globby": "^14.0.2",
-        "junk": "^4.0.1",
-        "micromatch": "^4.0.7",
-        "p-filter": "^4.1.0",
-        "p-map": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -4088,13 +2897,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
-      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4114,44 +2916,22 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
-      "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4174,34 +2954,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/edge-error": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/edge-error/-/edge-error-4.0.2.tgz",
@@ -4210,75 +2962,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.16.0"
-      }
-    },
-    "node_modules/edge-lexer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/edge-lexer/-/edge-lexer-6.0.4.tgz",
-      "integrity": "sha512-rHlTSZUQfBu/fwnAjoaLCGGmDzpRPgUC8FEqNdJtpPEjBRCqU3a4Le7iJ8KSQfY2WvWx6NTGAwti62xj3eIz1w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "edge-error": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=18.16.0"
-      }
-    },
-    "node_modules/edge-parser": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/edge-parser/-/edge-parser-9.1.0.tgz",
-      "integrity": "sha512-Z7sEbRNjjGuUVch3ELHMbjgksVjQlAjUASCwUWe+1I+nJ0mVBmUD2rn6zyes/+EjLssvEGQcIWMjLMNn1ChXgQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "astring": "^1.9.0",
-        "edge-error": "^4.0.2",
-        "edge-lexer": "^6.0.4",
-        "js-stringify": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=18.16.0"
-      }
-    },
-    "node_modules/edge.js": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/edge.js/-/edge.js-6.4.0.tgz",
-      "integrity": "sha512-c19PeUKrADqu+XBr8wSKdjqW/L65xiEfBMh9nbTx6ieF3SV7Ajb3PdfvrYPuLnobgs/bwtem1+InYVFSaWPc1A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@poppinss/inspect": "^1.0.1",
-        "@poppinss/macroable": "^1.1.0",
-        "@poppinss/utils": "^7.0.0-next.4",
-        "edge-error": "^4.0.2",
-        "edge-lexer": "^6.0.4",
-        "edge-parser": "^9.0.4",
-        "he": "^1.2.0",
-        "property-information": "^7.1.0",
-        "stringify-attributes": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.16.0"
-      }
-    },
-    "node_modules/edge.js/node_modules/@poppinss/utils": {
-      "version": "7.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.0-next.7.tgz",
-      "integrity": "sha512-Jwc6YqiLf8wAarEpC2bzamq5XIe3i553LeCzZhqYamSK1zZjYoa6tEPjKq1ASARjuNpYQAj96TLBw/yXJJDF/A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@poppinss/exception": "^1.2.3",
-        "@poppinss/object-builder": "^1.1.0",
-        "@poppinss/string": "^1.7.1",
-        "@poppinss/types": "^1.2.1",
-        "flattie": "^1.1.1"
       }
     },
     "node_modules/edgejs-parser": {
@@ -4317,13 +3000,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -4379,16 +3055,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -4406,59 +3072,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -4467,20 +3080,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-goat": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
-      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4886,34 +3485,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4927,38 +3498,6 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -5012,23 +3551,6 @@
         }
       }
     },
-    "node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5043,9 +3565,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5146,19 +3668,19 @@
       }
     },
     "node_modules/flydrive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flydrive/-/flydrive-1.3.0.tgz",
-      "integrity": "sha512-B0wsqrZR76d+J2ce6AxNcA1JDo4pViluaaFp5Fjso52zGY+s19uF8rKsQS8TJJsiyySKPI1b8K1w2j3RAUxd1Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/flydrive/-/flydrive-2.1.0.tgz",
+      "integrity": "sha512-464Y3vfAZKI3h+LodtjjFMnMxiItyHTKVGzfb2RBYzPfFl1gG7/RstlXH7bhUgB34h44lO9Cm4ZDW8UEk6Jd5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@humanwhocodes/retry": "^0.4.3",
-        "@poppinss/utils": "^6.10.0",
+        "@poppinss/utils": "^7.0.0-next.6",
         "etag": "^1.8.1",
-        "mime-types": "^3.0.1"
+        "mime-types": "^3.0.2"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
         "@aws-sdk/client-s3": "^3.577.0",
@@ -5177,24 +3699,18 @@
         }
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
-      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+    "node_modules/flydrive/node_modules/@poppinss/utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
-      "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "@poppinss/object-builder": "^1.1.0",
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
       }
     },
     "node_modules/forwarded": {
@@ -5215,22 +3731,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -5256,31 +3756,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -5289,62 +3764,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-source": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
-      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "data-uri-to-buffer": "^2.0.0",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/getopts": {
@@ -5380,90 +3799,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
-        "path-type": "^6.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby/node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
-      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^7.0.1",
-        "byte-counter": "^0.1.0",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.12",
-        "decompress-response": "^10.0.0",
-        "form-data-encoder": "^4.0.2",
-        "http2-wrapper": "^2.2.1",
-        "keyv": "^5.5.3",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^4.0.1",
-        "responselike": "^4.0.2",
-        "type-fest": "^4.26.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5474,23 +3809,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5540,13 +3862,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5568,42 +3883,14 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http2-wrapper": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
     "node_modules/ical-generator": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-7.2.0.tgz",
-      "integrity": "sha512-7I34QvxWqIRthaao81lmapa0OjftfDaSBZmADjV0IqxVMUWT5ywlATRsv/hZN9Rgf2VgRsnMY+xUUaA4ZvAJLA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-10.2.0.tgz",
+      "integrity": "sha512-XR5FsiDWCsz5MwBwMA/sQqR3A9H240xkXIeXOabV7uNAiieP+TA9rleVvlwPLRXMz+CXME8cGuDd7cdnE5At6w==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "uuid-random": "^1.3.2"
-      },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "20 || 22 || >=24"
       },
       "peerDependencies": {
         "@touch4it/ical-timezones": ">=1.6.0",
@@ -5884,47 +4171,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5947,14 +4193,6 @@
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
-    },
-    "node_modules/js-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6020,30 +4258,6 @@
         "node": "*"
       }
     },
-    "node_modules/junk": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
-      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
-      }
-    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -6055,9 +4269,9 @@
       }
     },
     "node_modules/knex": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz",
-      "integrity": "sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.2.9.tgz",
+      "integrity": "sha512-dtAILTjBMaG8YloP5oBxohDIKyIsdQ/TkcVvSjhsksvsjeH63Y0PADyuMDfNZKbVT3Rlx3vEYVBlecbPT/KerA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6082,6 +4296,9 @@
       "engines": {
         "node": ">=16"
       },
+      "peerDependencies": {
+        "pg-query-stream": "^4.14.0"
+      },
       "peerDependenciesMeta": {
         "better-sqlite3": {
           "optional": true
@@ -6098,6 +4315,9 @@
         "pg-native": {
           "optional": true
         },
+        "pg-query-stream": {
+          "optional": true
+        },
         "sqlite3": {
           "optional": true
         },
@@ -6107,18 +4327,101 @@
       }
     },
     "node_modules/knex-dynamic-connection": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/knex-dynamic-connection/-/knex-dynamic-connection-3.2.0.tgz",
-      "integrity": "sha512-+j6KeUSim0FR8EobOqA1a/TZbN9mahjzHzJgOfQVkv6PUnSqJp70c/5n63M2YVNgNHETyBIUhV8stuQ0T/mG3g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/knex-dynamic-connection/-/knex-dynamic-connection-5.0.1.tgz",
+      "integrity": "sha512-7/e1rnxg58dcWJxhi7zBqKesUf8I4Lgd94SvZ5J8ZBDaLV7lS80koUeFBTU+NJnVbRvCyZbZp6hbmZHXjk8+Bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
-        "knex": "^3.1.0"
+        "debug": "^4.4.3",
+        "knex": "3.2.7"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=24.0.0"
       }
+    },
+    "node_modules/knex-dynamic-connection/node_modules/knex": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.2.7.tgz",
+      "integrity": "sha512-VxdDE72x7Tc08E5yCu8HqYoeOm0HOjAraOtYiGSAUJTYkydwfSGBOpQqYHrzM5vjLNzw2JDL2vDH8m7DjIjtgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "2.0.19",
+        "commander": "^10.0.0",
+        "debug": "4.3.4",
+        "escalade": "^3.1.1",
+        "esm": "^3.2.25",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
+        "interpret": "^2.2.0",
+        "lodash": "^4.17.21",
+        "pg-connection-string": "2.6.2",
+        "rechoir": "^0.8.0",
+        "resolve-from": "^5.0.0",
+        "tarn": "^3.0.2",
+        "tildify": "2.0.0"
+      },
+      "bin": {
+        "knex": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "pg-query-stream": "^4.14.0"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "mysql": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-native": {
+          "optional": true
+        },
+        "pg-query-stream": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/knex-dynamic-connection/node_modules/knex/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/knex-dynamic-connection/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/knex/node_modules/debug": {
       "version": "4.3.4",
@@ -6145,6 +4448,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6159,26 +4475,10 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -6197,17 +4497,17 @@
       "license": "MIT"
     },
     "node_modules/log-update": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-7.1.0.tgz",
-      "integrity": "sha512-y9pi/ZOQQVvTgfRDEHV1Cj4zQUkJZPipEUNOxhn1R6KgmdMs7LKvXWCd9eMVPGJgvYzFLCenecWr0Ps8ChVv2A==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-7.2.0.tgz",
+      "integrity": "sha512-iLs7dGSyjZiUgvrUvuD3FndAxVJk+TywBkkkwUSm9HdYoskJalWg5qVsEiXeufPvRVPbCUmNQewg798rx+sPXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^7.1.0",
+        "ansi-escapes": "^7.3.0",
         "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.2",
-        "strip-ansi": "^7.1.2",
-        "wrap-ansi": "^9.0.2"
+        "slice-ansi": "^8.0.0",
+        "strip-ansi": "^7.2.0",
+        "wrap-ansi": "^10.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -6230,32 +4530,19 @@
       }
     },
     "node_modules/log-update/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -6290,16 +4577,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -6308,34 +4585,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/memoize": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.2.0.tgz",
-      "integrity": "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mimic-function": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
-      }
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
@@ -6405,53 +4654,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6459,52 +4661,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -6514,9 +4676,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
       "dev": true,
       "license": "MIT-0",
       "engines": {
@@ -6538,51 +4700,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/normalize-url": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -6591,19 +4708,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -6663,110 +4767,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
-      "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/p-event": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
-      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-event/node_modules/p-timeout": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-filter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
-      "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-map": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
@@ -6778,17 +4778,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/package-manager-detector": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
-      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "quansync": "^0.2.7"
       }
     },
     "node_modules/parent-module": {
@@ -6805,17 +4794,20 @@
       }
     },
     "node_modules/parse-imports": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
-      "integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-3.0.0.tgz",
+      "integrity": "sha512-IwiqoJANa4O6M76LBWEvoS2iPIUqBOnKG1lV3/J0oVM6V2XjED+mYAXedEMX5xUglVjfGpZOfaEyuOUjBuUE4g==",
       "dev": true,
       "license": "Apache-2.0 AND MIT",
       "dependencies": {
-        "es-module-lexer": "^1.5.3",
+        "es-module-lexer": "^1.7.0",
         "slashes": "^3.0.12"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/TomerAberbach"
       }
     },
     "node_modules/parse-json": {
@@ -6836,28 +4828,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6874,20 +4844,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-type": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/pg-connection-string": {
       "version": "2.6.2",
@@ -6982,36 +4938,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7102,30 +5028,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/pretty-ms": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
-      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "parse-ms": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/printable-characters": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
-      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
-      "dev": true,
-      "license": "Unlicense"
-    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -7142,18 +5044,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/property-information": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
-      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -7179,91 +5069,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/quansync": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
-      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/antfu"
-        },
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/sxzz"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
@@ -7371,21 +5182,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -7433,12 +5229,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -7453,13 +5250,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -7468,22 +5258,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
-      "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -7523,98 +5297,6 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -7693,82 +5375,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7803,17 +5409,17 @@
       "license": "ISC"
     },
     "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -7850,27 +5456,6 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/spdx-correct": {
@@ -7932,17 +5517,6 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/stacktracey": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
-      "integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "as-table": "^1.0.36",
-        "get-source": "^2.0.12"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7954,18 +5528,17 @@
       }
     },
     "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7985,36 +5558,19 @@
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/stringify-attributes": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-attributes/-/stringify-attributes-4.0.0.tgz",
-      "integrity": "sha512-6Hq3K153wTTfhEHb4V/viuqmb0DRn08JCrRnmqc4Q/tmoNuvd4DEyqkiiJXtvVz8ZSUhlCQr7zCpCVTgrelesg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "escape-goat": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-ansi": {
@@ -8028,20 +5584,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-indent": {
@@ -8071,9 +5613,9 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8162,6 +5704,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
@@ -8191,14 +5746,6 @@
       "integrity": "sha512-LeQRS7/4JcC0PgdSFnfUiStQEdiuySlCj/5SJ18D+T1n9BoY7PxKFfCwLulpHXoLUFr67HxBddQdEX47lDGx1g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -8280,18 +5827,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/ts-morph": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-23.0.0.tgz",
-      "integrity": "sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@ts-morph/common": "~0.24.0",
-        "code-block-writer": "^13.0.1"
       }
     },
     "node_modules/tslib": {
@@ -8393,19 +5928,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
@@ -8425,20 +5947,6 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -8491,13 +5999,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid-random": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
-      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -8517,84 +6018,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-plugin-restart": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-restart/-/vite-plugin-restart-0.4.2.tgz",
-      "integrity": "sha512-9aWN2ScJ8hbT7aC8SDeZnsbWapnslz1vhNq6Vgf2GU9WdN4NExlrWhtnu7pmtOUG3Guj8y6lPcUZ+ls7SVP33w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "micromatch": "^4.0.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "vite": "^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/which": {
@@ -8623,26 +6046,19 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -8675,13 +6091,13 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -8691,52 +6107,13 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/youch": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
-      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^0.7.1",
-        "mustache": "^4.2.0",
-        "stacktracey": "^2.1.8"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/youch-core": {
@@ -8748,60 +6125,6 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
-      }
-    },
-    "node_modules/youch-terminal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/youch-terminal/-/youch-terminal-2.2.3.tgz",
-      "integrity": "sha512-/PE77ZwG072tXBvF47S9RL9/G80u86icZ5QwyjblyM67L4n/T5qQeM3Xrecbu8kkDDr/9T/PTj/X+6G/OSRQug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^4.1.5",
-        "string-width": "^4.2.3",
-        "wordwrap": "^1.0.0"
-      }
-    },
-    "node_modules/youch-terminal/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/youch-terminal/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/youch-terminal/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/youch/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@escalated-dev/escalated-adonis",
-  "description": "An embeddable support ticket system for AdonisJS v6 applications",
+  "description": "An embeddable support ticket system for AdonisJS v7 applications",
   "version": "0.5.0",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "type": "module",
   "license": "MIT",
   "main": "build/index.js",
@@ -54,14 +57,14 @@
     "plugins"
   ],
   "peerDependencies": {
-    "@adonisjs/auth": "^9.0.0",
-    "@adonisjs/cache": "^1.0.0",
-    "@adonisjs/core": "^6.0.0",
-    "@adonisjs/drive": "^3.0.0",
-    "@adonisjs/inertia": "^1.0.0",
-    "@adonisjs/lucid": "^21.0.0",
-    "@adonisjs/mail": "^9.0.0",
-    "@adonisjs/transmit": "^2.0.0",
+    "@adonisjs/auth": "^10.0.0",
+    "@adonisjs/cache": "^2.0.0",
+    "@adonisjs/core": "^7.0.0",
+    "@adonisjs/drive": "^4.0.0",
+    "@adonisjs/inertia": "^4.0.0",
+    "@adonisjs/lucid": "^22.0.0",
+    "@adonisjs/mail": "^10.0.0",
+    "@adonisjs/transmit": "^3.0.0",
     "adm-zip": "^0.5.0"
   },
   "peerDependenciesMeta": {
@@ -73,17 +76,17 @@
     }
   },
   "devDependencies": {
-    "@adonisjs/auth": "^9.2.0",
-    "@adonisjs/cache": "^1.0.0",
-    "@adonisjs/core": "^6.14.0",
-    "@adonisjs/drive": "^3.0.0",
+    "@adonisjs/auth": "^10.1.0",
+    "@adonisjs/cache": "^2.1.0",
+    "@adonisjs/core": "^7.3.2",
+    "@adonisjs/drive": "^4.0.0",
     "@adonisjs/eslint-config": "^3.0.0",
-    "@adonisjs/inertia": "^1.2.0",
-    "@adonisjs/lucid": "^21.3.0",
-    "@adonisjs/mail": "^9.0.0",
+    "@adonisjs/inertia": "^4.2.0",
+    "@adonisjs/lucid": "^22.4.2",
+    "@adonisjs/mail": "^10.2.0",
     "@adonisjs/prettier-config": "^1.4.5",
-    "@adonisjs/session": "^7.6.0",
-    "@adonisjs/transmit": "^2.0.0",
+    "@adonisjs/session": "^8.1.0",
+    "@adonisjs/transmit": "^3.0.1",
     "@japa/runner": "^5.3.0",
     "@types/adm-zip": "^0.5.5",
     "@types/luxon": "^3.7.1",

--- a/src/controllers/admin_departments_controller.ts
+++ b/src/controllers/admin_departments_controller.ts
@@ -1,6 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import Department from '../models/department.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { redirectToRoute } from '../support/routing.js'
 import { t } from '../support/i18n.js'
 
 export default class AdminDepartmentsController {
@@ -34,7 +35,7 @@ export default class AdminDepartmentsController {
       isActive: data.is_active !== false,
     })
     session.flash('success', t('admin.department_created'))
-    return response.redirect().toRoute('escalated.admin.departments.index')
+    return redirectToRoute(response, 'escalated.admin.departments.index')
   }
 
   async edit(ctx: HttpContext) {
@@ -53,13 +54,13 @@ export default class AdminDepartmentsController {
     })
     await department.save()
     session.flash('success', t('admin.department_updated'))
-    return response.redirect().toRoute('escalated.admin.departments.index')
+    return redirectToRoute(response, 'escalated.admin.departments.index')
   }
 
   async destroy({ params, response, session }: HttpContext) {
     const department = await Department.findOrFail(params.id)
     await department.delete()
     session.flash('success', t('admin.department_deleted'))
-    return response.redirect().toRoute('escalated.admin.departments.index')
+    return redirectToRoute(response, 'escalated.admin.departments.index')
   }
 }

--- a/src/controllers/admin_escalation_rules_controller.ts
+++ b/src/controllers/admin_escalation_rules_controller.ts
@@ -1,6 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import EscalationRule from '../models/escalation_rule.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { redirectToRoute } from '../support/routing.js'
 import { t } from '../support/i18n.js'
 
 export default class AdminEscalationRulesController {
@@ -35,7 +36,7 @@ export default class AdminEscalationRulesController {
     })
 
     session.flash('success', t('admin.rule_created'))
-    return response.redirect().toRoute('escalated.admin.escalation-rules.index')
+    return redirectToRoute(response, 'escalated.admin.escalation-rules.index')
   }
 
   async edit(ctx: HttpContext) {
@@ -67,13 +68,13 @@ export default class AdminEscalationRulesController {
     await rule.save()
 
     session.flash('success', t('admin.rule_updated'))
-    return response.redirect().toRoute('escalated.admin.escalation-rules.index')
+    return redirectToRoute(response, 'escalated.admin.escalation-rules.index')
   }
 
   async destroy({ params, response, session }: HttpContext) {
     const rule = await EscalationRule.findOrFail(params.id)
     await rule.delete()
     session.flash('success', t('admin.rule_deleted'))
-    return response.redirect().toRoute('escalated.admin.escalation-rules.index')
+    return redirectToRoute(response, 'escalated.admin.escalation-rules.index')
   }
 }

--- a/src/controllers/admin_import_controller.ts
+++ b/src/controllers/admin_import_controller.ts
@@ -23,6 +23,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import ImportJob from '../models/import_job.js'
 import ImportService from '../services/import_service.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { redirectToRoute } from '../support/routing.js'
 
 export default class AdminImportController {
   protected importService = new ImportService()
@@ -105,7 +106,7 @@ export default class AdminImportController {
 
     await job.transitionTo('mapping')
 
-    return ctx.response.redirect().toRoute('escalated.admin.import.mapping', { id: job.id })
+    return redirectToRoute(ctx.response, 'escalated.admin.import.mapping', { id: job.id })
   }
 
   // --------------------------------------------------------------------------
@@ -123,7 +124,7 @@ export default class AdminImportController {
 
     if (!adapter) {
       ctx.session.flash('error', `Adapter for '${job.platform}' is no longer available.`)
-      return ctx.response.redirect().toRoute('escalated.admin.import.index')
+      return redirectToRoute(ctx.response, 'escalated.admin.import.index')
     }
 
     // Fetch available source fields for each entity type
@@ -165,7 +166,7 @@ export default class AdminImportController {
     await job.save()
 
     ctx.session.flash('success', 'Field mappings saved. You can now start the import.')
-    return ctx.response.redirect().toRoute('escalated.admin.import.show', { id: job.id })
+    return redirectToRoute(ctx.response, 'escalated.admin.import.show', { id: job.id })
   }
 
   // --------------------------------------------------------------------------
@@ -207,7 +208,7 @@ export default class AdminImportController {
     })
 
     ctx.session.flash('success', 'Import started. Refresh this page to track progress.')
-    return ctx.response.redirect().toRoute('escalated.admin.import.show', { id: job.id })
+    return redirectToRoute(ctx.response, 'escalated.admin.import.show', { id: job.id })
   }
 
   // --------------------------------------------------------------------------
@@ -229,7 +230,7 @@ export default class AdminImportController {
     await job.transitionTo('paused')
 
     ctx.session.flash('success', 'Import will pause after the current batch completes.')
-    return ctx.response.redirect().toRoute('escalated.admin.import.show', { id: job.id })
+    return redirectToRoute(ctx.response, 'escalated.admin.import.show', { id: job.id })
   }
 
   // --------------------------------------------------------------------------
@@ -251,7 +252,7 @@ export default class AdminImportController {
     await job.delete()
 
     ctx.session.flash('success', 'Import job deleted.')
-    return ctx.response.redirect().toRoute('escalated.admin.import.index')
+    return redirectToRoute(ctx.response, 'escalated.admin.import.index')
   }
 
   // --------------------------------------------------------------------------
@@ -263,7 +264,7 @@ export default class AdminImportController {
 
     if (!job) {
       ctx.session.flash('error', 'Import job not found.')
-      ctx.response.redirect().toRoute('escalated.admin.import.index')
+      redirectToRoute(ctx.response, 'escalated.admin.import.index')
       return null
     }
 

--- a/src/controllers/admin_plugins_controller.ts
+++ b/src/controllers/admin_plugins_controller.ts
@@ -12,6 +12,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import PluginService from '../services/plugin_service.js'
 import type HookManager from '../support/hook_manager.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { redirectToRoute } from '../support/routing.js'
 
 export default class AdminPluginsController {
   protected getPluginService(): PluginService {
@@ -50,7 +51,7 @@ export default class AdminPluginsController {
       await pluginService.uploadPlugin(file)
 
       ctx.session.flash('success', 'Plugin uploaded successfully. You can now activate it.')
-      return ctx.response.redirect().toRoute('escalated.admin.plugins.index')
+      return redirectToRoute(ctx.response, 'escalated.admin.plugins.index')
     } catch (error: any) {
       console.error('[Escalated] Plugin upload failed:', error)
       ctx.session.flash('error', `Failed to upload plugin: ${error.message}`)

--- a/src/controllers/admin_sla_policies_controller.ts
+++ b/src/controllers/admin_sla_policies_controller.ts
@@ -2,6 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import SlaPolicy from '../models/sla_policy.js'
 import { getConfig } from '../helpers/config.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { redirectToRoute } from '../support/routing.js'
 import { t } from '../support/i18n.js'
 
 export default class AdminSlaPoliciesController {
@@ -39,7 +40,7 @@ export default class AdminSlaPoliciesController {
     })
 
     session.flash('success', t('admin.sla_policy_created'))
-    return response.redirect().toRoute('escalated.admin.sla-policies.index')
+    return redirectToRoute(response, 'escalated.admin.sla-policies.index')
   }
 
   async edit(ctx: HttpContext) {
@@ -75,13 +76,13 @@ export default class AdminSlaPoliciesController {
     await policy.save()
 
     session.flash('success', t('admin.sla_policy_updated'))
-    return response.redirect().toRoute('escalated.admin.sla-policies.index')
+    return redirectToRoute(response, 'escalated.admin.sla-policies.index')
   }
 
   async destroy({ params, response, session }: HttpContext) {
     const policy = await SlaPolicy.findOrFail(params.id)
     await policy.delete()
     session.flash('success', t('admin.sla_policy_deleted'))
-    return response.redirect().toRoute('escalated.admin.sla-policies.index')
+    return redirectToRoute(response, 'escalated.admin.sla-policies.index')
   }
 }

--- a/src/controllers/customer_tickets_controller.ts
+++ b/src/controllers/customer_tickets_controller.ts
@@ -3,6 +3,7 @@ import Department from '../models/department.js'
 import TicketService from '../services/ticket_service.js'
 import { getConfig } from '../helpers/config.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { redirectToRoute } from '../support/routing.js'
 import { t } from '../support/i18n.js'
 
 export default class CustomerTicketsController {
@@ -56,9 +57,9 @@ export default class CustomerTicketsController {
     })
 
     session.flash('success', t('ticket.created'))
-    return response
-      .redirect()
-      .toRoute('escalated.customer.tickets.show', { ticket: ticket.reference })
+    return redirectToRoute(response, 'escalated.customer.tickets.show', {
+      ticket: ticket.reference,
+    })
   }
 
   /**

--- a/src/controllers/guest_tickets_controller.ts
+++ b/src/controllers/guest_tickets_controller.ts
@@ -10,6 +10,7 @@ import AttachmentService from '../services/attachment_service.js'
 import { ESCALATED_EVENTS } from '../events/index.js'
 import { getConfig } from '../helpers/config.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { redirectToRoute } from '../support/routing.js'
 import type { TicketPriority } from '../types.js'
 import { t } from '../support/i18n.js'
 
@@ -86,7 +87,9 @@ export default class GuestTicketsController {
     await emitter.emit(ESCALATED_EVENTS.TICKET_CREATED, { ticket })
 
     session.flash('success', t('guest.created'))
-    return response.redirect().toRoute('escalated.guest.tickets.show', { token: ticket.guestToken })
+    return redirectToRoute(response, 'escalated.guest.tickets.show', {
+      token: ticket.guestToken,
+    })
   }
 
   /**

--- a/src/support/routing.ts
+++ b/src/support/routing.ts
@@ -1,0 +1,42 @@
+/*
+|--------------------------------------------------------------------------
+| Routing helpers
+|--------------------------------------------------------------------------
+|
+| AdonisJS 7 made `response.redirect().toRoute()` and the related
+| `urlFor` / `signedUrlFor` URL builders type-safe against a host-augmented
+| `RoutesList` interface. Plugins can't know the host's full route set
+| (and a permissive plugin-side augmentation of `RoutesList` runs into
+| TypeScript's module-augmentation rules: the original interface is
+| re-exported via several paths so a plain `declare module` augmentation
+| in the plugin doesn't reach every relative import inside the framework).
+|
+| These helpers wrap the underlying runtime calls (which still accept any
+| string identifier — only the static types tightened) so plugin code can
+| call them with plugin-defined route names like
+| `escalated.admin.tickets.index` without fighting the new conditional
+| types.
+|
+*/
+
+import type { HttpContext } from '@adonisjs/core/http'
+
+/**
+ * Redirect to a named route. Mirrors the runtime semantics of
+ * `response.redirect().toRoute(name, params?)` but accepts any string
+ * identifier (the route name set is registered by the plugin's own
+ * `route_registrar` and is not part of the host's `RoutesList`).
+ */
+export function redirectToRoute(
+  response: HttpContext['response'],
+  name: string,
+  params?: Record<string, any>
+): void {
+  // The Adonis 7 type for `.toRoute(...args)` collapses to `[]` when the
+  // host hasn't augmented `RoutesList`, so we cast to a compatible runtime
+  // signature. The runtime still accepts (name, params) unchanged.
+  const redirect = response.redirect() as unknown as {
+    toRoute(name: string, params?: Record<string, any>): void
+  }
+  redirect.toRoute(name, params)
+}

--- a/src/types/augmentations.ts
+++ b/src/types/augmentations.ts
@@ -14,8 +14,28 @@
 | in the d.ts files that augment @adonisjs/core/http, keeping the package
 | self-contained and compilable without touching its runtime output.
 |
+| AdonisJS 7 also made Router.toRoute() and Inertia.render() type-safe
+| against host-augmented `RoutesList` and `InertiaPages` interfaces. A
+| plugin can't know the host's full route name set or page component set
+| ahead of time, so we widen both with permissive index signatures so the
+| package's own controllers (which use plugin-defined route names like
+| `escalated.admin.tickets.index` and Inertia component paths like
+| `Escalated/Admin/Tickets/Index`) type-check in isolation without losing
+| host-side specificity (host augmentations merge on top of these).
+|
 */
 
 import '@adonisjs/auth/initialize_auth_middleware'
 import '@adonisjs/session/session_middleware'
 import '@adonisjs/inertia/inertia_middleware'
+
+declare module '@adonisjs/inertia/types' {
+  /**
+   * Permissive InertiaPages augmentation. Lets `ctx.inertia.render('SomeComponent', props)`
+   * accept any string component path. The host app may further narrow this with
+   * its own page set.
+   */
+  interface InertiaPages {
+    [component: string]: Record<string, any>
+  }
+}


### PR DESCRIPTION
## Summary

Upgrades the package to AdonisJS 7, which lets us land four Dependabot PRs that all require `@adonisjs/core@^7.0.0` + `node>=24.0.0` and could not be merged individually:

- #58 — `@adonisjs/auth` 9.6 → 10.1
- #59 — `@adonisjs/drive` 3.4 → 4.0
- #60 — `@adonisjs/lucid` 21.8 → 22.4
- #62 — `@adonisjs/session` 7.6 → 8.1

Plus the underlying `@adonisjs/core` 6.14 → 7.3, `@adonisjs/inertia` 1.x → 4.x, `mail` 9 → 10, `cache` 1 → 2, `transmit` 2 → 3.

## What changed

**Package metadata**
- `package.json`: every `@adonisjs/*` peer + dev range bumped to v7-compatible versions; `engines.node` set to `>=24.0.0`
- `docker/Dockerfile`: base image `node:22-alpine` → `node:24-alpine`; peer-package install lines updated to `^10/^2/^4/^4/^10`
- `.github/workflows/{lint,run-tests}.yml`: matrix collapsed to Node 24 only (v7 floor)
- `README.md`, `CHANGELOG.md`: reflect the new version requirements

**Type-system fixups for v7's stricter URL builder + Inertia render types**

AdonisJS 7 made `response.redirect().toRoute()` and `ctx.inertia.render()` type-safe against host-augmented `RoutesList` and `InertiaPages` interfaces. Since this is a plugin that ships its own route names (`escalated.admin.tickets.index`, …) and Inertia component paths (`Escalated/Admin/Tickets/Index`, …) — and the host has no way to know about them at compile-time — we widen the types on the plugin side without losing host-side specificity:

- `src/types/augmentations.ts` — widen `InertiaPages` via `declare module '@adonisjs/inertia/types'` with a permissive `[component: string]: Record<string, any>` index signature. Host augmentations still merge.
- `src/support/routing.ts` (new) — small `redirectToRoute(response, name, params?)` helper. The same `RoutesList` augmentation trick doesn't reach `redirect.d.ts`'s relative `'./types/url_builder.ts'` import in any of the four module-paths I tried (`@adonisjs/core/http`, `@adonisjs/http-server`, `@adonisjs/http-server/types`, `@adonisjs/core/types/http`), so this wrapper does the cast in one place and the controllers stay readable.
- 11 call sites across 7 controllers updated to use `redirectToRoute` (admin_departments, admin_escalation_rules, admin_import, admin_plugins, admin_sla_policies, customer_tickets, guest_tickets). No runtime behaviour change.

**Repo hygiene (separate first commit on the same branch)**

- Reformat `.github/dependabot.yml` with prettier — was the actual cause of the long-running CI lint-job failure on `main`. Hadn't been re-formatted after a manual edit, and `npm run format:check` rejects it.

## Test plan

- [x] `npm install --legacy-peer-deps` resolves cleanly (no ERESOLVE, 36 packages added / 171 removed / 61 changed)
- [x] `npm run build` succeeds (tsc + copy-stubs)
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 466/466 tests pass
- [ ] CI green on PR
- [ ] Smoke test: docker compose up demo app and hit `/demo` once CI confirms the pipeline

## Closes

- Closes #58
- Closes #59
- Closes #60
- Closes #62

## Risks

- The `redirectToRoute` helper is the only behavioural surface area touched; runtime is unchanged. If the host has narrowed `RoutesList`, the helper still works (it falls through to the same runtime call).
- The Dockerfile demo install pattern still uses `--legacy-peer-deps` — required because the SDK plugin tarball declares wider peer ranges than v7's tightened ones.
- This PR does NOT touch any service that participates in Workflows / Automations / Macros / inbound resolution priorities — it is purely a dep upgrade.