### PR TITLE
fix(migration): assign explicit name to satisfaction_ratings rated_by index

### DIFF
--- a/database/migrations/0014_create_escalated_satisfaction_ratings.ts
+++ b/database/migrations/0014_create_escalated_satisfaction_ratings.ts
@@ -20,7 +20,7 @@ export default class CreateEscalatedSatisfactionRatings extends BaseSchema {
       table.integer('rated_by_id').unsigned().nullable()
       table.timestamp('created_at', { useTz: true }).nullable()
 
-      table.index(['rated_by_type', 'rated_by_id'])
+      table.index(['rated_by_type', 'rated_by_id'], 'satisfaction_ratings_rated_by_idx')
     })
   }
 


### PR DESCRIPTION
## Summary

Fixes a Lucid migration failure on PostgreSQL caused by an auto-generated index name exceeding the 63-char identifier limit.

The current line generates `escalated_satisfaction_ratings_rated_by_type_rated_by_id_index` (65 chars). PostgreSQL caps identifiers at 63 chars (NAMEDATALEN-1) and MySQL at 64; PostgreSQL fails outright, MySQL is exactly at the limit. Any user installing fresh on PostgreSQL with the default `escalated_` table prefix hits this.

Same class of bug as escalated-laravel#86 / #87.

## Backwards compatibility

Each migration runs only once and is tracked in `adonis_schema`:

1. **Migration already succeeded** (MySQL or SQLite): the user's schema has the long auto-generated name. Migration won't re-run, so the new explicit name only matters for fresh installs.
2. **Migration failed** (default prefix on PostgreSQL): nothing was created. The fix unblocks them.

No existing install can be broken by this change.

## Test plan

- [ ] `node ace migration:run` succeeds on a clean PostgreSQL database
- [ ] CI passes
