### PR TITLE
feat(admin): users-management page with admin/agent role toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Admin Users management page (`GET /support/admin/users`) and role-toggle endpoint (`PATCH /support/admin/users/:user/role`) that mirror the Laravel reference (escalated-laravel#94). Admins can grant or revoke the `is_admin` / `is_agent` flags on host users; admins cannot demote themselves, and revoking the agent flag from a user who is also admin cascades to clear admin too. Renders the shared `Escalated/Admin/Users/Index` Inertia page.
 - Consume translations from the central `@escalated-dev/locale` npm package. The package is loaded as the base layer, this package's `resources/lang/{locale}/messages.json` files are deep-merged on top as overrides, and host apps can drop further overrides into `resources/lang/overrides/{locale}/messages.json`. See `resources/lang/overrides/README.md` for the layering rules and a sample `config/i18n.ts` chain for `@adonisjs/i18n` v3+.
 
 ### Changed

--- a/resources/lang/en/messages.json
+++ b/resources/lang/en/messages.json
@@ -51,7 +51,9 @@
     "tag_created": "Tag created.",
     "tag_updated": "Tag updated.",
     "tag_deleted": "Tag deleted.",
-    "settings_updated": "Settings updated."
+    "settings_updated": "Settings updated.",
+    "user_updated": "User updated.",
+    "cannot_remove_own_admin": "You cannot remove your own admin role."
   },
   "middleware": {
     "not_admin": "You are not authorized as a support administrator.",

--- a/src/controllers/admin_users_controller.ts
+++ b/src/controllers/admin_users_controller.ts
@@ -1,0 +1,240 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { getRenderer } from '../rendering/renderer.js'
+import { t } from '../support/i18n.js'
+
+/**
+ * Surface enough of the host User table for an admin to grant or revoke
+ * agent / admin access from the panel. Mirrors the pinned `is_admin` /
+ * `is_agent` columns the install workflow tells hosts to add — hosts
+ * using a different role implementation (Spatie-style packages, custom
+ * pivots, etc.) should override this controller in their own routes.
+ *
+ * Adonis port of `escalated-laravel`'s `Admin\UserController`.
+ */
+export default class AdminUsersController {
+  /**
+   * GET /support/admin/users — List users with their admin/agent flags.
+   *
+   * Renders the shared Inertia page with a Laravel-paginator-shaped
+   * payload so the Vue component (which is the same one used by the
+   * Laravel reference plugin) can iterate `users.data` and render
+   * `users.links` for page navigation.
+   */
+  async index(ctx: HttpContext) {
+    const UserModel = await this.loadUserModel()
+
+    const search = String(ctx.request.input('search', '') ?? '').trim()
+    const page = Math.max(1, Number.parseInt(String(ctx.request.input('page', 1)), 10) || 1)
+    const perPage = 20
+
+    const query = UserModel.query()
+
+    if (search) {
+      const like = `%${search}%`
+      query.where((sub: any) => {
+        sub.where('email', 'like', like)
+        if (this.userHasNameColumn(UserModel)) {
+          sub.orWhere('name', 'like', like)
+        }
+      })
+    }
+
+    // is_admin DESC, is_agent DESC, id ASC — admins first, then agents.
+    query.orderBy('is_admin', 'desc').orderBy('is_agent', 'desc').orderBy('id', 'asc')
+
+    const paginator = await query.paginate(page, perPage)
+
+    const mapped = paginator.all().map((user: any) => ({
+      id: user.id,
+      name: user.name ?? null,
+      email: user.email,
+      is_admin: Boolean(user.isAdmin ?? user.is_admin ?? false),
+      is_agent: Boolean(user.isAgent ?? user.is_agent ?? false),
+    }))
+
+    const authUser = (ctx as any).auth?.user as { id?: number | string } | undefined
+
+    return getRenderer().render(ctx, 'Escalated/Admin/Users/Index', {
+      users: this.toLaravelPaginatorShape(paginator, mapped, ctx, { search }),
+      filters: { search },
+      currentUserId: authUser?.id ?? null,
+    })
+  }
+
+  /**
+   * PATCH /support/admin/users/:user/role — Grant/revoke admin or agent role.
+   *
+   * Body: `{ role: 'admin' | 'agent', value: boolean }`.
+   *
+   * Cross-flag semantics (mirrors the Laravel reference exactly):
+   *   - `role=admin`, `value=true`  → also force `is_agent=true`
+   *     (admins are agents by definition).
+   *   - `role=admin`, `value=false` → just turn admin off; the demoted
+   *     admin keeps their agent flag.
+   *   - `role=agent`, `value=true`  → just turn agent on.
+   *   - `role=agent`, `value=false` AND the target is currently admin →
+   *     also force `is_admin=false`, otherwise the admin gate stays on
+   *     with the agent gate off (confusing for the user).
+   *
+   * Safety: an authenticated admin cannot demote themselves (would lock
+   * them out of the panel they're using). We redirect-back with an
+   * `error` flash and skip the update entirely.
+   */
+  async updateRole(ctx: HttpContext) {
+    const { request, response, session, params } = ctx
+
+    const role = String(request.input('role', '')).trim()
+    const valueRaw = request.input('value')
+    const value = valueRaw === true || valueRaw === 'true' || valueRaw === 1 || valueRaw === '1'
+
+    if (role !== 'admin' && role !== 'agent') {
+      session.flash('error', 'Invalid role.')
+      return response.redirect().back()
+    }
+
+    const UserModel = await this.loadUserModel()
+    const target = await UserModel.findOrFail(params.user)
+
+    const authUser = (ctx as any).auth?.user as { id?: number | string } | undefined
+
+    // Don't let an admin demote themselves and lock themselves out.
+    if (role === 'admin' && !value && authUser && String(authUser.id) === String(target.id)) {
+      session.flash('error', t('admin.cannot_remove_own_admin'))
+      return response.redirect().back()
+    }
+
+    if (role === 'admin') {
+      target.isAdmin = value
+      // Admins are agents; promoting to admin auto-enables agent.
+      // Demoting from admin does NOT auto-revoke agent — an ex-admin
+      // can still answer tickets unless explicitly demoted.
+      if (value) {
+        target.isAgent = true
+      }
+    } else {
+      target.isAgent = value
+      // Revoking agent from an admin leaves the admin gate on but the
+      // agent gate off — confusing. Demote them fully.
+      if (!value && (target.isAdmin ?? target.is_admin ?? false)) {
+        target.isAdmin = false
+      }
+    }
+
+    await target.save()
+
+    session.flash('success', t('admin.user_updated'))
+    return response.redirect().back()
+  }
+
+  // ─── helpers ─────────────────────────────────────────────────────
+
+  /**
+   * Lazy-resolve the host User model via `config.userModel` (the same
+   * path other admin controllers, e.g. `admin_api_tokens_controller`,
+   * import the user model from).
+   */
+  protected async loadUserModel(): Promise<any> {
+    const config = (globalThis as any).__escalated_config
+    const userModelPath = config?.userModel ?? '#models/user'
+    const mod: any = await import(userModelPath)
+    return mod.default
+  }
+
+  /**
+   * Best-effort check that the model has a `name` column. Falls back to
+   * `true` so search still works on hosts where introspection fails.
+   */
+  protected userHasNameColumn(UserModel: any): boolean {
+    try {
+      const columns = UserModel?.$columnsDefinitions
+      if (columns && typeof columns.has === 'function') {
+        return columns.has('name')
+      }
+    } catch {
+      // ignore
+    }
+    return true
+  }
+
+  /**
+   * Adonis Lucid paginators serialize as `{ meta, data }` whereas the
+   * shared Vue page (and the Laravel reference plugin) expect Laravel's
+   * `{ data, current_page, last_page, per_page, total, links }` shape —
+   * including a `links` array of `{ url, label, active }` entries with
+   * "« Previous", numbered pages, and "Next »" markers.
+   *
+   * We shim that here so the same Inertia component works against the
+   * Adonis backend without changes.
+   */
+  protected toLaravelPaginatorShape(
+    paginator: any,
+    data: any[],
+    ctx: HttpContext,
+    extraQuery: Record<string, string | number | undefined>
+  ): Record<string, any> {
+    const currentPage: number = paginator.currentPage ?? 1
+    const lastPage: number = paginator.lastPage ?? 1
+    const perPage: number = paginator.perPage ?? data.length
+    const total: number =
+      paginator.total ??
+      (typeof paginator.getTotal === 'function' ? paginator.getTotal() : data.length)
+
+    const baseUrl = ctx.request.url(false)
+
+    const buildUrl = (page: number | null): string | null => {
+      if (page === null) return null
+      const params = new URLSearchParams()
+      for (const [k, v] of Object.entries(extraQuery)) {
+        if (v !== undefined && v !== null && v !== '') {
+          params.set(k, String(v))
+        }
+      }
+      params.set('page', String(page))
+      const qs = params.toString()
+      return qs ? `${baseUrl}?${qs}` : baseUrl
+    }
+
+    const links: { url: string | null; label: string; active: boolean }[] = []
+
+    // « Previous
+    links.push({
+      url: currentPage > 1 ? buildUrl(currentPage - 1) : null,
+      label: '&laquo; Previous',
+      active: false,
+    })
+
+    // numbered pages — match Laravel's behaviour of emitting one entry
+    // per page (the Vue template hides the whole block when there are
+    // <= 3 links, so a tiny single-page response correctly disappears).
+    for (let p = 1; p <= lastPage; p++) {
+      links.push({
+        url: buildUrl(p),
+        label: String(p),
+        active: p === currentPage,
+      })
+    }
+
+    // Next »
+    links.push({
+      url: currentPage < lastPage ? buildUrl(currentPage + 1) : null,
+      label: 'Next &raquo;',
+      active: false,
+    })
+
+    return {
+      data,
+      current_page: currentPage,
+      last_page: lastPage,
+      per_page: perPage,
+      total,
+      from: data.length > 0 ? (currentPage - 1) * perPage + 1 : null,
+      to: data.length > 0 ? (currentPage - 1) * perPage + data.length : null,
+      first_page_url: buildUrl(1),
+      last_page_url: buildUrl(lastPage),
+      next_page_url: currentPage < lastPage ? buildUrl(currentPage + 1) : null,
+      prev_page_url: currentPage > 1 ? buildUrl(currentPage - 1) : null,
+      path: baseUrl,
+      links,
+    }
+  }
+}

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -41,6 +41,7 @@ const AdminApiTokensController = () => import('../src/controllers/admin_api_toke
 const AdminImportController = () => import('../src/controllers/admin_import_controller.js')
 const AdminAutomationsController = () =>
   import('../src/controllers/admin_automations_controller.js')
+const AdminUsersController = () => import('../src/controllers/admin_users_controller.js')
 
 // Lazy-load controllers (core — non-UI)
 const InboundEmailController = () => import('../src/controllers/inbound_email_controller.js')
@@ -537,6 +538,12 @@ function registerUiRoutes(config: any) {
       router
         .delete('/automations/:id', [AdminAutomationsController, 'destroy'])
         .as('escalated.admin.automations.destroy')
+
+      // Users (host User model: list + grant/revoke admin/agent)
+      router.get('/users', [AdminUsersController, 'index']).as('escalated.admin.users.index')
+      router
+        .patch('/users/:user/role', [AdminUsersController, 'updateRole'])
+        .as('escalated.admin.users.role')
 
       // Plugins
       router.get('/plugins', [AdminPluginsController, 'index']).as('escalated.admin.plugins.index')

--- a/tests/admin_users.test.js
+++ b/tests/admin_users.test.js
@@ -1,0 +1,245 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+/*
+|--------------------------------------------------------------------------
+| Admin Users Controller Tests
+|--------------------------------------------------------------------------
+|
+| Mirrors the Laravel reference (`tests/Feature/Admin/UserControllerTest.php`
+| in escalated-laravel) for feature parity. Like the rest of the
+| escalated-adonis test suite, these are pure-function tests: we re-implement
+| the controller's decision logic (role-flip semantics, self-demote guard,
+| list ordering, search filter) and assert on the resulting state — no
+| Lucid / no HTTP. Integration coverage lives in the host-app harness.
+|
+*/
+
+// ──────────────────────────────────────────────────────────────────
+// Re-implement controller helpers
+// ──────────────────────────────────────────────────────────────────
+
+/**
+ * Decide what to do for `updateRole({ role, value })` against a target
+ * user, given the authenticated admin's id. Returns one of:
+ *   - `{ action: 'forbid_self_demote' }`            — admin demoting self
+ *   - `{ action: 'invalid_role' }`                  — role !== admin|agent
+ *   - `{ action: 'update', updates: { is_admin?, is_agent? } }`
+ *
+ * Mirrors AdminUsersController.updateRole().
+ */
+function decideRoleUpdate(target, role, value, authUserId) {
+  if (role !== 'admin' && role !== 'agent') {
+    return { action: 'invalid_role' }
+  }
+
+  if (
+    role === 'admin' &&
+    !value &&
+    authUserId !== null &&
+    String(authUserId) === String(target.id)
+  ) {
+    return { action: 'forbid_self_demote' }
+  }
+
+  const updates = {}
+  if (role === 'admin') {
+    updates.is_admin = value
+    if (value) {
+      // Admins are agents; promoting to admin auto-enables agent.
+      updates.is_agent = true
+    }
+  } else {
+    updates.is_agent = value
+    if (!value && target.is_admin) {
+      // Revoking agent from an admin: also demote admin to avoid a
+      // confusing "admin gate on, agent gate off" state.
+      updates.is_admin = false
+    }
+  }
+  return { action: 'update', updates }
+}
+
+/**
+ * Re-implement the index() ordering — `is_admin DESC`, `is_agent DESC`,
+ * `id ASC`. Returns a copy sorted in-place.
+ */
+function sortUsers(users) {
+  return [...users].sort((a, b) => {
+    if (a.is_admin !== b.is_admin) return a.is_admin ? -1 : 1
+    if (a.is_agent !== b.is_agent) return a.is_agent ? -1 : 1
+    return a.id - b.id
+  })
+}
+
+/**
+ * Re-implement the index() search filter — case-insensitive substring
+ * match against `email` OR (`name` if present).
+ */
+function searchUsers(users, term) {
+  if (!term) return users
+  const needle = term.toLowerCase()
+  return users.filter((u) => {
+    if (typeof u.email === 'string' && u.email.toLowerCase().includes(needle)) return true
+    if (typeof u.name === 'string' && u.name.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
+/**
+ * Apply an `updates` object (as returned by decideRoleUpdate) to a target
+ * user and return the result.
+ */
+function applyUpdates(target, updates) {
+  return { ...target, ...updates }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Tests — one per parity case from the Laravel reference suite
+// ──────────────────────────────────────────────────────────────────
+
+describe('Admin Users — list', () => {
+  it('lists users with their admin/agent flags', () => {
+    // Mirrors: "lists users with their admin/agent flags for an admin"
+    const users = [
+      { id: 1, name: 'Admin', email: 'admin@example.com', is_admin: true, is_agent: true },
+      { id: 2, name: 'Customer', email: 'customer@example.com', is_admin: false, is_agent: false },
+      { id: 3, name: 'Agent', email: 'agent@example.com', is_admin: false, is_agent: true },
+    ]
+    const sorted = sortUsers(users)
+    const emails = sorted.map((u) => u.email)
+    assert.ok(emails.includes('admin@example.com'))
+    assert.ok(emails.includes('customer@example.com'))
+    assert.ok(emails.includes('agent@example.com'))
+    // Admins surface first, then agents, then customers.
+    assert.equal(sorted[0].email, 'admin@example.com')
+    assert.equal(sorted[1].email, 'agent@example.com')
+    assert.equal(sorted[2].email, 'customer@example.com')
+  })
+
+  it('filters users by search term against name or email', () => {
+    // Mirrors: "filters users by search term"
+    const users = [
+      { id: 1, name: 'Admin', email: 'admin@example.com', is_admin: true, is_agent: true },
+      { id: 2, name: 'Jane Doe', email: 'jane@acme.test', is_admin: false, is_agent: false },
+      { id: 3, name: 'Bob Smith', email: 'bob@globex.test', is_admin: false, is_agent: false },
+    ]
+    const filtered = searchUsers(users, 'acme')
+    const emails = filtered.map((u) => u.email)
+    assert.ok(emails.includes('jane@acme.test'))
+    assert.ok(!emails.includes('bob@globex.test'))
+  })
+})
+
+describe('Admin Users — role gate', () => {
+  it('blocks non-admins from the user list at the middleware layer', () => {
+    // Mirrors: "blocks non-admins from the user list"
+    //
+    // The actual gate is enforced by `EnsureIsAdmin` middleware (mounted
+    // on the `/support/admin` group in `start/routes.ts`), which calls
+    // `config.authorization.isAdmin(user)` and 403s on false. We mirror
+    // that decision here.
+    function ensureIsAdmin(user, isAdminCheck) {
+      if (!user) return { status: 403 }
+      return isAdminCheck(user) ? { status: 200 } : { status: 403 }
+    }
+    const isAdminCheck = (u) => Boolean(u.is_admin)
+
+    const agent = { id: 1, is_admin: false, is_agent: true }
+    const admin = { id: 2, is_admin: true, is_agent: true }
+
+    assert.equal(ensureIsAdmin(agent, isAdminCheck).status, 403)
+    assert.equal(ensureIsAdmin(admin, isAdminCheck).status, 200)
+    assert.equal(ensureIsAdmin(null, isAdminCheck).status, 403)
+  })
+})
+
+describe('Admin Users — updateRole', () => {
+  it('promotes a user to admin (and forces is_agent=true)', () => {
+    // Mirrors: "promotes a user to admin via the panel"
+    const target = { id: 10, is_admin: false, is_agent: false }
+    const decision = decideRoleUpdate(target, 'admin', true, 1)
+
+    assert.equal(decision.action, 'update')
+    assert.equal(decision.updates.is_admin, true)
+    assert.equal(decision.updates.is_agent, true)
+
+    const after = applyUpdates(target, decision.updates)
+    assert.equal(after.is_admin, true)
+    assert.equal(after.is_agent, true)
+  })
+
+  it('promotes a user to agent only (is_admin stays false)', () => {
+    // Mirrors: "promotes a user to agent only"
+    const target = { id: 10, is_admin: false, is_agent: false }
+    const decision = decideRoleUpdate(target, 'agent', true, 1)
+
+    assert.equal(decision.action, 'update')
+    assert.equal(decision.updates.is_agent, true)
+    assert.equal(decision.updates.is_admin, undefined)
+
+    const after = applyUpdates(target, decision.updates)
+    assert.equal(after.is_agent, true)
+    assert.equal(after.is_admin, false)
+  })
+
+  it('prevents admins from demoting themselves', () => {
+    // Mirrors: "prevents admins from demoting themselves"
+    const admin = { id: 1, is_admin: true, is_agent: true }
+    const decision = decideRoleUpdate(admin, 'admin', false, 1)
+
+    assert.equal(decision.action, 'forbid_self_demote')
+
+    // No updates applied — admin keeps their flags.
+    const after = decision.updates ? applyUpdates(admin, decision.updates) : admin
+    assert.equal(after.is_admin, true)
+  })
+
+  it('lets a different admin demote a target admin (no self-guard tripped)', () => {
+    // Edge case under the same code path: the self-guard must only fire
+    // when authUserId === target.id, not for every admin-demote.
+    const target = { id: 2, is_admin: true, is_agent: true }
+    const decision = decideRoleUpdate(target, 'admin', false, 1)
+
+    assert.equal(decision.action, 'update')
+    assert.equal(decision.updates.is_admin, false)
+    // is_agent NOT touched by an admin-off flip (an ex-admin can still
+    // answer tickets unless explicitly demoted as an agent).
+    assert.equal(decision.updates.is_agent, undefined)
+  })
+
+  it('demotes an admin and turns off agent in one step', () => {
+    // Mirrors: "demotes an admin and turns off agent in one step"
+    //
+    // Revoking the agent role from someone who is also an admin must
+    // also clear is_admin so the admin gate doesn't stay on while the
+    // agent gate is off.
+    const target = { id: 2, is_admin: true, is_agent: true }
+    const decision = decideRoleUpdate(target, 'agent', false, 1)
+
+    assert.equal(decision.action, 'update')
+    assert.equal(decision.updates.is_agent, false)
+    assert.equal(decision.updates.is_admin, false)
+
+    const after = applyUpdates(target, decision.updates)
+    assert.equal(after.is_agent, false)
+    assert.equal(after.is_admin, false)
+  })
+
+  it('demoting a non-admin agent does not touch is_admin', () => {
+    // Same code path, opposite branch: target is a plain agent (not
+    // admin) — turning their agent flag off must leave is_admin alone.
+    const target = { id: 3, is_admin: false, is_agent: true }
+    const decision = decideRoleUpdate(target, 'agent', false, 1)
+
+    assert.equal(decision.action, 'update')
+    assert.equal(decision.updates.is_agent, false)
+    assert.equal(decision.updates.is_admin, undefined)
+  })
+
+  it('rejects unknown role values', () => {
+    const target = { id: 3, is_admin: false, is_agent: false }
+    const decision = decideRoleUpdate(target, 'superadmin', true, 1)
+    assert.equal(decision.action, 'invalid_role')
+  })
+})


### PR DESCRIPTION
## Summary

Port the Admin Users management feature from `escalated-laravel#94` (https://github.com/escalated-dev/escalated-laravel/pull/94) to escalated-adonis for feature parity across host plugins.

- New `AdminUsersController` exposes:
  - `GET /support/admin/users` (`escalated.admin.users.index`) — list host users with `is_admin` / `is_agent` flags, paginated 20/page, sorted `is_admin DESC, is_agent DESC, id ASC`, with `search` filter on `email` (and `name` when the column exists).
  - `PATCH /support/admin/users/:user/role` (`escalated.admin.users.role`) — `{ role: admin|agent, value: bool }` body. Admin-on auto-enables agent; agent-off cascades to admin-off when the target is currently admin. The currently authenticated admin cannot demote themselves.
- Routes registered under the existing admin group in `start/routes.ts`, so the existing `EnsureIsAdmin` middleware already gates them.
- Renders the shared Vue page `Escalated/Admin/Users/Index` from `@escalated-dev/escalated`. Inertia payload is shimmed into Laravel-paginator shape (`data`, `current_page`, `links: [...]`, etc.) so the same component works against the Adonis backend unchanged.
- i18n: `admin.user_updated` and `admin.cannot_remove_own_admin` added to `resources/lang/en/messages.json` (overrides on top of central `@escalated-dev/locale`).
- Tests: `tests/admin_users.test.js` mirrors the 7 reference cases from `tests/Feature/Admin/UserControllerTest.php` (list, non-admin forbidden, promote-admin both-flags, promote-agent only, prevent self-demote, agent-off cascades to admin-off, search filter) plus 3 branch-coverage cases — pure-function style consistent with the rest of the suite.

Refs: escalated-dev/escalated-laravel#94

## Deviations from the Laravel reference

- The Adonis test suite is pure-function (no HTTP / no Lucid in-test), so the 7 parity cases re-implement the controller decision logic instead of round-tripping through the router. This matches every other test file in the repo (e.g. `tests/saved_views.test.js`, `tests/kb_toggle_settings.test.js`).
- Lucid paginators serialize as `{ meta, data }`, but the shared Vue component expects Laravel's `{ data, current_page, links: [...] }` shape. The controller includes a small `toLaravelPaginatorShape` helper to bridge the gap.
- `@escalated-dev/escalated` is not listed in this repo''s `package.json` (it ships only as the host-app frontend dependency, separately from the Adonis npm package), so there was nothing to bump to `^0.8.0` inside this repo. The shared Vue page is consumed from the host application.

## Test plan

- [x] `npm test` — full suite passes (476 tests, +10 new under `tests/admin_users.test.js`).
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] `npx tsc --noEmit` — no new errors introduced (4 pre-existing `sso_service.ts` Element/Document errors unrelated to this PR).