### PR TITLE
feat(tickets): custom ticket actions via events

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,53 @@ The package emits the following events that you can listen to:
 | `escalated:note:created` | Internal note added |
 | `escalated:sla:breached` | SLA target breached |
 | `escalated:rating:created` | CSAT rating submitted |
+| `escalated:ticket:customActionTriggered` | Agent triggered a custom ticket action |
+
+## Custom Ticket Actions
+
+Host applications can add custom buttons to the agent ticket screen and handle
+clicks with a normal event listener. Register actions in `config/escalated.ts`:
+
+```ts
+const escalatedConfig: EscalatedConfig = {
+  // ...
+  ticketActions: {
+    actions: [
+      {
+        key: 'sync-crm',
+        label: 'Sync CRM',
+        variant: 'primary',                // primary | secondary | danger
+        confirmation: 'Sync this ticket to the CRM?',
+        metadata: { icon: 'refresh-cw' },
+        // visible / enabled may be a boolean or (ticket, user) => boolean
+        enabled: (ticket) => !ticket.metadata?.crm_synced,
+      },
+    ],
+  },
+}
+```
+
+For richer logic, an entry may instead be an object implementing the
+`TicketAction` contract (`src/contracts/ticket_action.ts`).
+
+Visible actions are exposed on the agent ticket show page as `customActions`
+and on the API ticket detail response as `custom_actions` (each with a `url`
+and `method`). Triggering one (`POST /<prefix>/agent/tickets/:ticket/actions/:action`
+or the API equivalent) validates the action is visible (404) and enabled (403),
+then emits `escalated:ticket:customActionTriggered`:
+
+```ts
+import emitter from '@adonisjs/core/services/emitter'
+import { ESCALATED_EVENTS } from '@escalated-dev/escalated-adonis'
+
+emitter.on(ESCALATED_EVENTS.TICKET_CUSTOM_ACTION_TRIGGERED, async (data) => {
+  if (data.action !== 'sync-crm') return
+  // data.ticket, data.user, data.payload, data.metadata
+})
+```
+
+Escalated also records an internal note on the ticket whenever an action fires,
+for auditability.
 
 ## Inbound Email
 

--- a/providers/escalated_provider.ts
+++ b/providers/escalated_provider.ts
@@ -135,6 +135,9 @@ export default class EscalatedProvider {
     // Wire AdonisJS emitter events → plugin bridge action hooks
     await this.wireEventsToBridge()
 
+    // Record an internal note whenever a custom ticket action is triggered
+    await this.registerCustomActionInternalNote()
+
     // Reset the cached renderer so it picks up the freshly-loaded config
     resetRenderer()
 
@@ -255,6 +258,33 @@ export default class EscalatedProvider {
       })
     } catch {
       // Inertia may not be available
+    }
+  }
+
+  /**
+   * Record an internal note on the ticket whenever a custom action is
+   * triggered, giving an audit trail of who ran which action. The note is
+   * authored by the triggering agent, so the body need not repeat their name.
+   */
+  protected async registerCustomActionInternalNote() {
+    try {
+      const { default: emitter } = await import('@adonisjs/core/services/emitter')
+      const { ESCALATED_EVENTS } = await import('../src/events/index.js')
+
+      emitter.on(ESCALATED_EVENTS.TICKET_CUSTOM_ACTION_TRIGGERED, async (data) => {
+        try {
+          const { default: TicketService } = await import('../src/services/ticket_service.js')
+          await new TicketService().addNote(
+            data.ticket,
+            data.user,
+            `Custom action "${data.action}" was triggered.`
+          )
+        } catch (err) {
+          console.warn('[Escalated] recording custom action note failed:', (err as Error).message)
+        }
+      })
+    } catch {
+      // Emitter unavailable — skip.
     }
   }
 

--- a/src/contracts/ticket_action.ts
+++ b/src/contracts/ticket_action.ts
@@ -1,0 +1,54 @@
+/*
+|--------------------------------------------------------------------------
+| Ticket Action contract
+|--------------------------------------------------------------------------
+|
+| Host applications register custom ticket actions on `config/escalated.ts`
+| under `ticketActions.actions` — either objects implementing TicketAction or
+| plain TicketActionConfig objects. Each visible action renders as a button on
+| the agent ticket screen; triggering it emits the
+| `escalated:ticket:customActionTriggered` event.
+|
+*/
+
+export interface TicketAction {
+  /** Stable identifier, used in the action URL and the emitted event. */
+  key(): string
+
+  /** Button label shown to the agent. */
+  label(ticket: any, user: any): string
+
+  /** Whether the action appears at all for this ticket/user. */
+  visible(ticket: any, user: any): boolean
+
+  /** Whether the button is clickable (vs. shown but disabled). */
+  enabled(ticket: any, user: any): boolean
+
+  /** Button style: 'primary' | 'secondary' | 'danger'. */
+  variant(): string
+
+  /** Optional confirmation prompt shown before the action fires. */
+  confirmation(ticket: any, user: any): string | null
+
+  /** Arbitrary metadata passed through to the UI and the event (e.g. icon). */
+  metadata(ticket: any, user: any): Record<string, any>
+}
+
+/** A value, or a function resolving it lazily from the ticket/user. */
+export type TicketActionValueOrFn<T> = T | ((ticket: any, user: any) => T)
+
+/** Plain-object form of a ticket action, resolved into a TicketAction by the registry. */
+export interface TicketActionConfig {
+  key: string
+  label: TicketActionValueOrFn<string>
+  variant?: string
+  visible?: TicketActionValueOrFn<boolean>
+  enabled?: TicketActionValueOrFn<boolean>
+  confirmation?: TicketActionValueOrFn<string | null>
+  metadata?: TicketActionValueOrFn<Record<string, any>>
+}
+
+/** Type guard: does the value already implement TicketAction? */
+export function isTicketAction(value: TicketAction | TicketActionConfig): value is TicketAction {
+  return typeof (value as TicketAction).key === 'function'
+}

--- a/src/controllers/agent_tickets_controller.ts
+++ b/src/controllers/agent_tickets_controller.ts
@@ -9,10 +9,14 @@ import ChatSession from '../models/chat_session.js'
 import TicketService from '../services/ticket_service.js'
 import AssignmentService from '../services/assignment_service.js'
 import MacroService from '../services/macro_service.js'
+import TicketActionRegistry from '../services/ticket_action_registry.js'
 import { getRenderer } from '../rendering/renderer.js'
+import { getConfig } from '../helpers/config.js'
 import type { TicketStatus, TicketPriority } from '../types.js'
 import { t } from '../support/i18n.js'
 import { requireAuthUser } from '../support/auth_user.js'
+import emitter from '@adonisjs/core/services/emitter'
+import { ESCALATED_EVENTS } from '../events/index.js'
 
 export default class AgentTicketsController {
   protected ticketService = new TicketService()
@@ -141,7 +145,52 @@ export default class AgentTicketsController {
       chat_metadata: chatSession?.metadata ?? ticket.chatMetadata ?? null,
       requester_ticket_count: requesterTicketCount,
       related_tickets: relatedTickets,
+      customActions: this.customActionsForTicket(ticket, ctx.auth.user),
     })
+  }
+
+  /**
+   * Serialize the visible custom actions for a ticket, adding url + method.
+   */
+  protected customActionsForTicket(ticket: Ticket, user: any): Array<Record<string, any>> {
+    const prefix = getConfig().routes?.prefix ?? 'support'
+    return new TicketActionRegistry().forTicket(ticket, user).map((action) => ({
+      ...action,
+      url: `/${prefix}/agent/tickets/${ticket.reference}/actions/${action.key}`,
+      method: 'post',
+    }))
+  }
+
+  /**
+   * POST /support/agent/tickets/:ticket/actions/:action — Trigger a custom action
+   */
+  async customAction(ctx: HttpContext) {
+    const ticket = (ctx as any).escalatedTicket as Ticket
+    const user = requireAuthUser(ctx.auth)
+    const actionKey = ctx.params.action
+
+    const registry = new TicketActionRegistry()
+    const action = registry.find(actionKey)
+
+    if (!action || !action.visible(ticket, user)) {
+      return ctx.response.notFound({ error: 'Custom action not found.' })
+    }
+    if (!action.enabled(ticket, user)) {
+      return ctx.response.forbidden({ error: 'Custom action is not enabled.' })
+    }
+
+    const { payload } = ctx.request.only(['payload'])
+
+    await emitter.emit(ESCALATED_EVENTS.TICKET_CUSTOM_ACTION_TRIGGERED, {
+      ticket,
+      action: action.key(),
+      user,
+      payload: payload ?? {},
+      metadata: action.metadata(ticket, user),
+    })
+
+    ctx.session.flash('success', 'Custom action dispatched.')
+    return ctx.response.redirect().back()
   }
 
   /**

--- a/src/controllers/api/api_ticket_controller.ts
+++ b/src/controllers/api/api_ticket_controller.ts
@@ -6,8 +6,12 @@ import ChatSession from '../../models/chat_session.js'
 import TicketService from '../../services/ticket_service.js'
 import AssignmentService from '../../services/assignment_service.js'
 import MacroService from '../../services/macro_service.js'
+import TicketActionRegistry from '../../services/ticket_action_registry.js'
+import { getConfig } from '../../helpers/config.js'
 import { STATUS_LABELS, PRIORITY_LABELS } from '../../types.js'
 import type { TicketStatus, TicketPriority } from '../../types.js'
+import emitter from '@adonisjs/core/services/emitter'
+import { ESCALATED_EVENTS } from '../../events/index.js'
 
 export default class ApiTicketController {
   protected ticketService = new TicketService()
@@ -86,14 +90,58 @@ export default class ApiTicketController {
     // Load related tickets (from split metadata links)
     const relatedTickets = await this.loadRelatedTickets(ticket)
 
-    return ctx.response.json({
-      data: await this.formatTicketDetail(ticket, {
-        chatSession,
-        chatMessages,
-        requesterTicketCount,
-        relatedTickets,
-      }),
+    const data = await this.formatTicketDetail(ticket, {
+      chatSession,
+      chatMessages,
+      requesterTicketCount,
+      relatedTickets,
     })
+    data.custom_actions = this.customActionsForTicket(ticket, (ctx as any).auth?.user)
+
+    return ctx.response.json({ data })
+  }
+
+  /**
+   * Serialize the visible custom actions for a ticket, adding url + method.
+   */
+  protected customActionsForTicket(ticket: Ticket, user: any): Array<Record<string, any>> {
+    const apiPrefix = getConfig().api?.prefix ?? 'support/api/v1'
+    return new TicketActionRegistry().forTicket(ticket, user).map((action) => ({
+      ...action,
+      url: `/${apiPrefix}/tickets/${ticket.reference}/actions/${action.key}`,
+      method: 'post',
+    }))
+  }
+
+  /**
+   * POST /tickets/:ticket/actions/:action — Trigger a custom ticket action
+   */
+  async customAction(ctx: HttpContext) {
+    const ticket = (ctx as any).escalatedTicket as Ticket
+    const user = (ctx as any).auth.user
+    const actionKey = ctx.params.action
+
+    const registry = new TicketActionRegistry()
+    const action = registry.find(actionKey)
+
+    if (!action || !action.visible(ticket, user)) {
+      return ctx.response.notFound({ message: 'Custom action not found.' })
+    }
+    if (!action.enabled(ticket, user)) {
+      return ctx.response.forbidden({ message: 'Custom action is not enabled.' })
+    }
+
+    const { payload } = ctx.request.only(['payload'])
+
+    await emitter.emit(ESCALATED_EVENTS.TICKET_CUSTOM_ACTION_TRIGGERED, {
+      ticket,
+      action: action.key(),
+      user,
+      payload: payload ?? {},
+      metadata: action.metadata(ticket, user),
+    })
+
+    return ctx.response.json({ message: 'Custom action dispatched.', action: action.key() })
   }
 
   /**

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -130,6 +130,14 @@ export interface ChatTransferredData {
   toAgentId: number
 }
 
+export interface TicketCustomActionTriggeredData {
+  ticket: Ticket
+  action: string
+  user: any
+  payload?: Record<string, any>
+  metadata?: Record<string, any>
+}
+
 // ---- Event Names ----
 
 export const ESCALATED_EVENTS = {
@@ -154,6 +162,7 @@ export const ESCALATED_EVENTS = {
   CHAT_ENDED: 'escalated:chat:ended',
   CHAT_MESSAGE: 'escalated:chat:message',
   CHAT_TRANSFERRED: 'escalated:chat:transferred',
+  TICKET_CUSTOM_ACTION_TRIGGERED: 'escalated:ticket:customActionTriggered',
 } as const
 
 // ---- Event type map for Adonis Emitter ----
@@ -180,6 +189,7 @@ export interface EscalatedEventsList {
   [ESCALATED_EVENTS.CHAT_ENDED]: ChatEndedData
   [ESCALATED_EVENTS.CHAT_MESSAGE]: ChatMessageData
   [ESCALATED_EVENTS.CHAT_TRANSFERRED]: ChatTransferredData
+  [ESCALATED_EVENTS.TICKET_CUSTOM_ACTION_TRIGGERED]: TicketCustomActionTriggeredData
 }
 
 /*
@@ -219,5 +229,6 @@ declare module '@adonisjs/core/types' {
     'escalated:chat:ended': ChatEndedData
     'escalated:chat:message': ChatMessageData
     'escalated:chat:transferred': ChatTransferredData
+    'escalated:ticket:customActionTriggered': TicketCustomActionTriggeredData
   }
 }

--- a/src/services/ticket_action_registry.ts
+++ b/src/services/ticket_action_registry.ts
@@ -1,0 +1,104 @@
+import { getConfig } from '../helpers/config.js'
+import {
+  isTicketAction,
+  type TicketAction,
+  type TicketActionConfig,
+  type TicketActionValueOrFn,
+} from '../contracts/ticket_action.js'
+
+/**
+ * Wraps a plain TicketActionConfig so it satisfies the TicketAction interface,
+ * resolving value-or-function fields lazily.
+ */
+class ArrayTicketAction implements TicketAction {
+  constructor(private config: TicketActionConfig) {
+    if (!config.key || !config.label) {
+      throw new Error('Ticket actions require both "key" and "label" values.')
+    }
+  }
+
+  key(): string {
+    return String(this.config.key)
+  }
+
+  label(ticket: any, user: any): string {
+    return String(this.resolve(this.config.label, ticket, user))
+  }
+
+  visible(ticket: any, user: any): boolean {
+    return Boolean(this.resolve(this.config.visible ?? true, ticket, user))
+  }
+
+  enabled(ticket: any, user: any): boolean {
+    return Boolean(this.resolve(this.config.enabled ?? true, ticket, user))
+  }
+
+  variant(): string {
+    return this.config.variant ?? 'secondary'
+  }
+
+  confirmation(ticket: any, user: any): string | null {
+    const value = this.resolve(this.config.confirmation ?? null, ticket, user)
+    return value === null || value === undefined ? null : String(value)
+  }
+
+  metadata(ticket: any, user: any): Record<string, any> {
+    const value = this.resolve(this.config.metadata ?? {}, ticket, user)
+    return value && typeof value === 'object' ? value : {}
+  }
+
+  private resolve<T>(value: TicketActionValueOrFn<T>, ticket: any, user: any): T {
+    return typeof value === 'function'
+      ? (value as (ticket: any, user: any) => T)(ticket, user)
+      : value
+  }
+}
+
+/**
+ * Holds the host application's registered custom ticket actions (from
+ * `config/escalated.ts` → `ticketActions.actions`) and resolves which are
+ * available for a given ticket/user.
+ */
+export default class TicketActionRegistry {
+  private actions = new Map<string, TicketAction>()
+
+  constructor() {
+    const configured = getConfig().ticketActions?.actions ?? []
+    for (const action of configured) {
+      this.register(action)
+    }
+  }
+
+  register(action: TicketAction | TicketActionConfig): this {
+    const resolved = isTicketAction(action) ? action : new ArrayTicketAction(action)
+    this.actions.set(resolved.key(), resolved)
+    return this
+  }
+
+  find(key: string): TicketAction | null {
+    return this.actions.get(key) ?? null
+  }
+
+  /**
+   * The actions visible to this ticket/user, serialized for the UI. The
+   * controller adds the `url` and `method` before sending to the client.
+   */
+  forTicket(ticket: any, user: any): Array<Record<string, any>> {
+    const result: Array<Record<string, any>> = []
+
+    for (const action of this.actions.values()) {
+      if (!action.visible(ticket, user)) continue
+
+      result.push({
+        key: action.key(),
+        label: action.label(ticket, user),
+        variant: action.variant(),
+        confirmation: action.confirmation(ticket, user),
+        disabled: !action.enabled(ticket, user),
+        metadata: action.metadata(ticket, user),
+      })
+    }
+
+    return result
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@
 */
 
 import { t } from './support/i18n.js'
+import type { TicketAction, TicketActionConfig } from './contracts/ticket_action.js'
 
 /**
  * Ticket statuses
@@ -247,6 +248,15 @@ export interface EscalatedConfig {
 
   ui: {
     enabled: boolean
+  }
+
+  /**
+   * Host-defined custom ticket actions. Each visible action renders as a button
+   * on the agent ticket screen and, when triggered, emits the
+   * `escalated:ticket:customActionTriggered` event.
+   */
+  ticketActions?: {
+    actions?: (TicketAction | TicketActionConfig)[]
   }
 
   api?: {

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -243,6 +243,9 @@ function registerUiRoutes(config: any) {
             .post('/tickets/:ticket/macro', [AgentTicketsController, 'applyMacro'])
             .as('escalated.agent.tickets.macro')
           router
+            .post('/tickets/:ticket/actions/:action', [AgentTicketsController, 'customAction'])
+            .as('escalated.agent.tickets.custom-action')
+          router
             .post('/tickets/:ticket/follow', [AgentTicketsController, 'follow'])
             .as('escalated.agent.tickets.follow')
           router
@@ -646,6 +649,9 @@ export function registerApiRoutes(config: any) {
           router
             .post('/tickets/:ticket/macro', [ApiTicketController, 'applyMacro'])
             .as('escalated.api.tickets.macro')
+          router
+            .post('/tickets/:ticket/actions/:action', [ApiTicketController, 'customAction'])
+            .as('escalated.api.tickets.custom-action')
           router
             .post('/tickets/:ticket/tags', [ApiTicketController, 'tags'])
             .as('escalated.api.tickets.tags')

--- a/stubs/config/escalated.stub
+++ b/stubs/config/escalated.stub
@@ -79,6 +79,20 @@ const escalatedConfig: EscalatedConfig = {
 
   /*
   |--------------------------------------------------------------------------
+  | Custom Ticket Actions
+  |--------------------------------------------------------------------------
+  |
+  | Host-defined action buttons shown on the agent ticket screen. Each may be
+  | a plain object ({ key, label, variant, visible, enabled, confirmation,
+  | metadata }) or an object implementing the TicketAction contract. Triggering
+  | one emits the `escalated:ticket:customActionTriggered` event.
+  */
+  ticketActions: {
+    actions: [],
+  },
+
+  /*
+  |--------------------------------------------------------------------------
   | Priorities
   |--------------------------------------------------------------------------
   */

--- a/tests/ticket_action_registry.test.js
+++ b/tests/ticket_action_registry.test.js
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+/*
+ * Mirrors the resolution semantics of src/services/ticket_action_registry.ts.
+ * Following the repo convention (see ticket_snooze.test.js) these tests model
+ * the behavior of the registry — value-or-function resolution, visibility
+ * filtering, and the disabled flag — independent of the AdonisJS runtime.
+ */
+
+function resolve(value, ticket, user) {
+  return typeof value === 'function' ? value(ticket, user) : value
+}
+
+function forTicket(actions, ticket, user) {
+  const result = []
+  for (const a of actions) {
+    if (!resolve(a.visible ?? true, ticket, user)) continue
+    const confirmation = resolve(a.confirmation ?? null, ticket, user)
+    result.push({
+      key: a.key,
+      label: String(resolve(a.label, ticket, user)),
+      variant: a.variant ?? 'secondary',
+      confirmation:
+        confirmation === null || confirmation === undefined ? null : String(confirmation),
+      disabled: !resolve(a.enabled ?? true, ticket, user),
+      metadata: resolve(a.metadata ?? {}, ticket, user),
+    })
+  }
+  return result
+}
+
+describe('TicketActionRegistry semantics', () => {
+  const ticket = { id: 1, reference: 'TK-1' }
+  const user = { id: 9 }
+
+  it('serializes a config action with sensible defaults', () => {
+    const [action] = forTicket([{ key: 'sync-crm', label: 'Sync CRM' }], ticket, user)
+    assert.deepEqual(action, {
+      key: 'sync-crm',
+      label: 'Sync CRM',
+      variant: 'secondary',
+      confirmation: null,
+      disabled: false,
+      metadata: {},
+    })
+  })
+
+  it('omits invisible actions and marks disabled ones', () => {
+    const actions = forTicket(
+      [
+        { key: 'hidden', label: 'Hidden', visible: false },
+        { key: 'locked', label: 'Locked', enabled: false },
+      ],
+      ticket,
+      user
+    )
+    assert.equal(actions.length, 1)
+    assert.equal(actions[0].key, 'locked')
+    assert.equal(actions[0].disabled, true)
+  })
+
+  it('resolves function fields with ticket + user', () => {
+    const [action] = forTicket(
+      [
+        {
+          key: 'dyn',
+          label: (t) => `Sync ${t.reference}`,
+          visible: (_t, u) => u.id === 9,
+          metadata: () => ({ icon: 'refresh-cw' }),
+        },
+      ],
+      ticket,
+      user
+    )
+    assert.equal(action.label, 'Sync TK-1')
+    assert.deepEqual(action.metadata, { icon: 'refresh-cw' })
+  })
+})


### PR DESCRIPTION
Ports the **Custom Ticket Actions** feature to the AdonisJS package. Backend counterpart to escalated-laravel#107 (reference: escalated-nestjs#57); shared frontend in escalated-dev/escalated#82.

## What
Host apps register actions on `config/escalated.ts` under `ticketActions.actions` — plain config objects (`{ key, label, variant, visible, enabled, confirmation, metadata }`, where `visible`/`enabled`/etc. may be `(ticket, user) => value`) or objects implementing the `TicketAction` contract. Visible actions are exposed on the agent show as `customActions` and on the API detail response as `custom_actions` (each with `url` + `method`). Triggering one emits `escalated:ticket:customActionTriggered`.

## Pieces
- `src/contracts/ticket_action.ts` — `TicketAction` + `ArrayTicketAction` config wrapper.
- `src/services/ticket_action_registry.ts` — loads from config.
- `TicketCustomActionTriggeredData` + `ESCALATED_EVENTS.TICKET_CUSTOM_ACTION_TRIGGERED` + `EventsList` module augmentation.
- Provider registers an emitter listener that records an internal note (audit).
- Agent + API `customAction` methods + routes (`POST /tickets/:ticket/actions/:action`), 404 not-visible / 403 disabled, and `customActions`/`custom_actions` serialization.
- `ticketActions` config (type + stub).
- README "Custom Ticket Actions" section.

## Testing
- `eslint` — clean on all changed files; `prettier --write` applied.
- `node --test` — added `ticket_action_registry.test.js` (registry semantics, matching the repo's self-contained test convention).
- **Note:** `tsc` surfaces 5 pre-existing type errors in `skill_routing_service.ts` / `sso_service.ts` (untouched files, present on `main`); none are in the files this PR changes. The package emits via `build:emit` (tolerant). CI gates are eslint + `node --test`.