### PR TITLE
feat(tickets): ticket subjects (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Ticket subjects: attach host-app entities (Project, Customer, asset, …) that a ticket is *about*, distinct from the requester. `TicketSubject` contract + `ticketSubjects` config (`types` allowlist, `resolver` for presentation). `TicketSubjectLink` model, `attachSubject` / `detachSubject` / `syncSubjects` on `Ticket`, agent/admin attach/detach routes, API/detail serialization as `subjects[]`.
 - Admin Users management page (`GET /support/admin/users`) and role-toggle endpoint (`PATCH /support/admin/users/:user/role`) that mirror the Laravel reference (escalated-laravel#94). Admins can grant or revoke the `is_admin` / `is_agent` flags on host users; admins cannot demote themselves, and revoking the agent flag from a user who is also admin cascades to clear admin too. Renders the shared `Escalated/Admin/Users/Index` Inertia page.
 - Consume translations from the central `@escalated-dev/locale` npm package. The package is loaded as the base layer, this package's `resources/lang/{locale}/messages.json` files are deep-merged on top as overrides, and host apps can drop further overrides into `resources/lang/overrides/{locale}/messages.json`. See `resources/lang/overrides/README.md` for the layering rules and a sample `config/i18n.ts` chain for `@adonisjs/i18n` v3+.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,64 @@ authorization: {
 }
 ```
 
+### Ticket subjects
+
+A ticket has a **requester** (who raised it) and a **subject line** (free text). Tickets can also be *about* host-app entities — a Project, Customer, asset — that are not people. Attach them as ticket **subjects** so agents see what the ticket concerns and can jump into your app.
+
+Implement the `TicketSubject` contract on any host model (or resolve presentation via config):
+
+```typescript
+import type { TicketSubject } from '@escalated-dev/escalated-adonis'
+
+export class Project implements TicketSubject {
+  ticketSubjectTitle() {
+    return this.name
+  }
+  ticketSubjectSubtitle() {
+    return `Project · ${this.customerName}`
+  }
+  ticketSubjectUrl() {
+    return `/projects/${this.id}`
+  }
+  ticketSubjectColor() {
+    return '#2563eb'
+  }
+  ticketSubjectIcon() {
+    return 'folder'
+  }
+}
+```
+
+Attach, detach, or sync on a ticket (several subjects allowed; `subject_id` is stored as a string):
+
+```typescript
+await ticket.attachSubject('Project', project.id, 'project')
+await ticket.detachSubject('Project', project.id)
+await ticket.syncSubjects([
+  { type: 'Project', id: project.id, role: 'primary' },
+  ['Customer', customer.id, 'account'],
+])
+```
+
+Configure allowed types and a resolver for API/UI serialization:
+
+```typescript
+ticketSubjects: {
+  types: ['Project', 'Customer'],
+  resolver: async (type, id) => {
+    if (type === 'Project') {
+      const row = await Project.find(id)
+      return row ?? null
+    }
+    return null
+  },
+},
+```
+
+Agent/admin routes: `POST …/tickets/:ticket/subjects` (`type`, `id`, optional `role`) and `DELETE …/tickets/:ticket/subjects/:linkId`. The API only accepts allowlisted types; programmatic `attachSubject()` allows any type when the allowlist is empty.
+
+Each subject is serialized as `{ type, id, role, title, subtitle, url, color, icon, missing }` (fallback title `type#id` when the resolver is absent or returns null).
+
 ## Features
 
 - **Tickets:** Create, view, update, close, reopen tickets with status machine

--- a/database/migrations/0051_create_escalated_ticket_subjects.ts
+++ b/database/migrations/0051_create_escalated_ticket_subjects.ts
@@ -1,0 +1,36 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * Ticket subjects — host-app entities a ticket is *about* (Project, Customer,
+ * asset, …), distinct from the requester and the subject *line* (free text).
+ * `subject_id` is a string so integer, UUID, ULID, or other host keys work.
+ */
+export default class CreateEscalatedTicketSubjects extends BaseSchema {
+  protected tableName = 'escalated_ticket_subjects'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table
+        .integer('ticket_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('escalated_tickets')
+        .onDelete('CASCADE')
+      table.string('subject_type').notNullable()
+      table.string('subject_id').notNullable()
+      table.string('role').nullable()
+      table.integer('position').unsigned().notNullable().defaultTo(0)
+      table.timestamp('created_at', { useTz: true }).notNullable()
+      table.timestamp('updated_at', { useTz: true }).notNullable()
+
+      table.unique(['ticket_id', 'subject_type', 'subject_id'])
+      table.index(['subject_type', 'subject_id'])
+    })
+  }
+
+  async down() {
+    this.schema.dropTableIfExists(this.tableName)
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -78,6 +78,14 @@ export { default as ImportService } from './src/services/import_service.js'
 export { default as ImportContext } from './src/support/import_context.js'
 export { ExtractResult } from './src/contracts/import_adapter.js'
 export type { ImportAdapter, CredentialField } from './src/contracts/import_adapter.js'
+export type {
+  TicketSubject,
+  SerializedTicketSubject,
+  TicketSubjectSyncItem,
+} from './src/contracts/ticket_subject.js'
+export { default as TicketSubjectLink } from './src/models/ticket_subject_link.js'
+export { default as TicketSubjectService } from './src/services/ticket_subject_service.js'
+export { TicketSubjectNotAllowedError } from './src/services/ticket_subject_service.js'
 export type { ImportJobStatus, EntityProgress, ErrorLogEntry } from './src/models/import_job.js'
 
 // Live Chat

--- a/src/contracts/ticket_subject.ts
+++ b/src/contracts/ticket_subject.ts
@@ -1,0 +1,28 @@
+/**
+ * A host-app entity that can be attached to a ticket as its *subject* — the
+ * thing the ticket is about (Project, Customer, asset, …), distinct from the
+ * requester.
+ */
+export interface TicketSubject {
+  ticketSubjectTitle(): string
+  ticketSubjectSubtitle(): string | null
+  ticketSubjectUrl(): string | null
+  ticketSubjectColor(): string | null
+  ticketSubjectIcon(): string | null
+}
+
+export type SerializedTicketSubject = {
+  type: string
+  id: string
+  role: string | null
+  title: string
+  subtitle: string | null
+  url: string | null
+  color: string | null
+  icon: string | null
+  missing: boolean
+}
+
+export type TicketSubjectSyncItem =
+  | { type: string; id: string; role?: string | null }
+  | [type: string, id: string, role?: string | null]

--- a/src/controllers/admin_tickets_controller.ts
+++ b/src/controllers/admin_tickets_controller.ts
@@ -13,6 +13,7 @@ import { getRenderer } from '../rendering/renderer.js'
 import type { TicketStatus, TicketPriority } from '../types.js'
 import { t } from '../support/i18n.js'
 import { requireAuthUser } from '../support/auth_user.js'
+import TicketSubjectService from '../services/ticket_subject_service.js'
 
 export default class AdminTicketsController {
   protected ticketService = new TicketService()
@@ -125,8 +126,11 @@ export default class AdminTicketsController {
     // Load related tickets via split metadata
     const relatedTickets = await this.loadRelatedTickets(ticket)
 
+    const subjects = await new TicketSubjectService().serializeForTicket(ticket)
+
     return getRenderer().render(ctx, 'Escalated/Admin/Tickets/Show', {
       ticket,
+      subjects,
       departments,
       tags,
       cannedResponses,

--- a/src/controllers/agent_tickets_controller.ts
+++ b/src/controllers/agent_tickets_controller.ts
@@ -15,6 +15,7 @@ import { getConfig } from '../helpers/config.js'
 import type { TicketStatus, TicketPriority } from '../types.js'
 import { t } from '../support/i18n.js'
 import { requireAuthUser } from '../support/auth_user.js'
+import TicketSubjectService from '../services/ticket_subject_service.js'
 import emitter from '@adonisjs/core/services/emitter'
 import { ESCALATED_EVENTS } from '../events/index.js'
 
@@ -125,8 +126,11 @@ export default class AgentTicketsController {
     // Load related tickets via split metadata
     const relatedTickets = await this.loadRelatedTickets(ticket)
 
+    const subjects = await new TicketSubjectService().serializeForTicket(ticket)
+
     return getRenderer().render(ctx, 'Escalated/Agent/TicketShow', {
       ticket,
+      subjects,
       departments,
       tags,
       cannedResponses,

--- a/src/controllers/api/api_ticket_controller.ts
+++ b/src/controllers/api/api_ticket_controller.ts
@@ -7,6 +7,7 @@ import TicketService from '../../services/ticket_service.js'
 import AssignmentService from '../../services/assignment_service.js'
 import MacroService from '../../services/macro_service.js'
 import TicketActionRegistry from '../../services/ticket_action_registry.js'
+import TicketSubjectService from '../../services/ticket_subject_service.js'
 import { getConfig } from '../../helpers/config.js'
 import { STATUS_LABELS, PRIORITY_LABELS } from '../../types.js'
 import type { TicketStatus, TicketPriority } from '../../types.js'
@@ -16,6 +17,7 @@ import { ESCALATED_EVENTS } from '../../events/index.js'
 export default class ApiTicketController {
   protected ticketService = new TicketService()
   protected assignmentService = new AssignmentService()
+  protected ticketSubjectService = new TicketSubjectService()
 
   /**
    * GET /tickets — List tickets with pagination and filtering
@@ -452,6 +454,7 @@ export default class ApiTicketController {
           name: tag.name,
           color: tag.color,
         })) ?? [],
+      subjects: await this.ticketSubjectService.serializeForTicket(ticket),
       replies: await Promise.all(
         (ticket.replies ?? []).map(async (r: any) => ({
           id: r.id,

--- a/src/controllers/ticket_subjects_controller.ts
+++ b/src/controllers/ticket_subjects_controller.ts
@@ -1,0 +1,96 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import type Ticket from '../models/ticket.js'
+import TicketSubjectLink from '../models/ticket_subject_link.js'
+import TicketSubjectService, {
+  assertTicketSubjectTypeAllowed,
+  ticketSubjectAllowedTypes,
+} from '../services/ticket_subject_service.js'
+
+/**
+ * Attach/detach host-app subject entities on a ticket. Types are resolved
+ * strictly against `ticketSubjects.types` so request input cannot attach
+ * arbitrary types when an allowlist is configured.
+ */
+export default class TicketSubjectsController {
+  protected subjectService = new TicketSubjectService()
+
+  /**
+   * POST …/tickets/:ticket/subjects
+   */
+  async store(ctx: HttpContext) {
+    const ticket = (ctx as any).escalatedTicket as Ticket
+    const { type, id, role } = ctx.request.only(['type', 'id', 'role'])
+
+    if (!type || typeof type !== 'string') {
+      return ctx.response.unprocessableEntity({
+        message: 'Validation failed.',
+        errors: { type: ['The type field is required.'] },
+      })
+    }
+
+    if (id === undefined || id === null || id === '') {
+      return ctx.response.unprocessableEntity({
+        message: 'Validation failed.',
+        errors: { id: ['The id field is required.'] },
+      })
+    }
+
+    const allowed = ticketSubjectAllowedTypes()
+    if (allowed.length === 0 || !allowed.includes(type)) {
+      return ctx.response.unprocessableEntity({
+        message: 'Validation failed.',
+        errors: { type: [`Subject type [${type}] is not an allowed ticket subject.`] },
+      })
+    }
+
+    try {
+      assertTicketSubjectTypeAllowed(type)
+    } catch {
+      return ctx.response.unprocessableEntity({
+        message: 'Validation failed.',
+        errors: { type: [`Subject type [${type}] is not an allowed ticket subject.`] },
+      })
+    }
+
+    await ticket.attachSubject(type, String(id), role ?? null)
+
+    if (ctx.request.accepts(['html', 'json']) === 'json') {
+      const subjects = await this.subjectService.serializeForTicket(ticket)
+      return ctx.response.json({ subjects })
+    }
+
+    ctx.session.flash('success', 'Subject attached.')
+    return ctx.response.redirect().back()
+  }
+
+  /**
+   * DELETE …/tickets/:ticket/subjects/:subject
+   */
+  async destroy(ctx: HttpContext) {
+    const ticket = (ctx as any).escalatedTicket as Ticket
+    const linkId = Number(ctx.params.subject)
+
+    if (Number.isNaN(linkId)) {
+      return ctx.response.notFound({ message: 'Subject link not found.' })
+    }
+
+    const link = await TicketSubjectLink.query()
+      .where('id', linkId)
+      .where('ticket_id', ticket.id)
+      .first()
+
+    if (!link) {
+      return ctx.response.notFound({ message: 'Subject link not found.' })
+    }
+
+    await link.delete()
+
+    if (ctx.request.accepts(['html', 'json']) === 'json') {
+      const subjects = await this.subjectService.serializeForTicket(ticket)
+      return ctx.response.json({ subjects })
+    }
+
+    ctx.session.flash('success', 'Subject detached.')
+    return ctx.response.redirect().back()
+  }
+}

--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -21,6 +21,9 @@ import TicketActivity from './ticket_activity.js'
 import Attachment from './attachment.js'
 import SatisfactionRating from './satisfaction_rating.js'
 import EscalatedSetting from './escalated_setting.js'
+import TicketSubjectLink from './ticket_subject_link.js'
+import { assertTicketSubjectTypeAllowed } from '../services/ticket_subject_service.js'
+import type { TicketSubjectSyncItem } from '../contracts/ticket_subject.js'
 
 export default class Ticket extends BaseModel {
   static table = 'escalated_tickets'
@@ -161,6 +164,9 @@ export default class Ticket extends BaseModel {
 
   @hasOne(() => SatisfactionRating, { foreignKey: 'ticketId' })
   declare satisfactionRating: HasOne<typeof SatisfactionRating>
+
+  @hasMany(() => TicketSubjectLink, { foreignKey: 'ticketId' })
+  declare subjects: HasMany<typeof TicketSubjectLink>
 
   // Note: "requester" and "assignee" are polymorphic / dynamic user model
   // references. We handle these by manually loading via the user model.
@@ -349,5 +355,78 @@ export default class Ticket extends BaseModel {
       .count('* as total')
       .first()
     return Number(result?.total ?? 0)
+  }
+
+  /**
+   * Attach a host entity as a subject (idempotent on ticket+type+id).
+   * Rejects types outside the configured allowlist when one is set.
+   */
+  async attachSubject(
+    subjectType: string,
+    subjectId: string | number,
+    role: string | null = null,
+    position?: number
+  ): Promise<TicketSubjectLink> {
+    assertTicketSubjectTypeAllowed(subjectType)
+
+    const id = String(subjectId)
+    const existing = await TicketSubjectLink.query()
+      .where('ticket_id', this.id)
+      .where('subject_type', subjectType)
+      .where('subject_id', id)
+      .first()
+
+    if (existing) {
+      existing.role = role
+      if (position !== undefined) {
+        existing.position = position
+      }
+      await existing.save()
+      return existing
+    }
+
+    let nextPosition = position
+    if (nextPosition === undefined) {
+      const maxRow = await TicketSubjectLink.query()
+        .where('ticket_id', this.id)
+        .max('position as max_position')
+        .first()
+      const maxPosition = Number((maxRow as any)?.$extras?.max_position ?? -1)
+      nextPosition = maxPosition + 1
+    }
+
+    return TicketSubjectLink.create({
+      ticketId: this.id,
+      subjectType,
+      subjectId: id,
+      role,
+      position: nextPosition,
+    })
+  }
+
+  /**
+   * Detach a subject by type+id. Returns the number of links removed (0 or 1).
+   */
+  async detachSubject(subjectType: string, subjectId: string | number): Promise<number> {
+    const deleted = await TicketSubjectLink.query()
+      .where('ticket_id', this.id)
+      .where('subject_type', subjectType)
+      .where('subject_id', String(subjectId))
+      .delete()
+
+    return Number(deleted[0] ?? 0)
+  }
+
+  /**
+   * Replace this ticket's subjects, preserving order.
+   */
+  async syncSubjects(items: TicketSubjectSyncItem[]): Promise<void> {
+    await TicketSubjectLink.query().where('ticket_id', this.id).delete()
+
+    let position = 0
+    for (const entry of items) {
+      const [type, id, role] = Array.isArray(entry) ? entry : [entry.type, entry.id, entry.role]
+      await this.attachSubject(type, id, role ?? null, position++)
+    }
   }
 }

--- a/src/models/ticket_subject_link.ts
+++ b/src/models/ticket_subject_link.ts
@@ -1,0 +1,38 @@
+import { type DateTime } from 'luxon'
+import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import Ticket from './ticket.js'
+
+/**
+ * Join row linking a ticket to one host-app subject (type + id).
+ */
+export default class TicketSubjectLink extends BaseModel {
+  static table = 'escalated_ticket_subjects'
+
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare ticketId: number
+
+  @column()
+  declare subjectType: string
+
+  @column()
+  declare subjectId: string
+
+  @column()
+  declare role: string | null
+
+  @column()
+  declare position: number
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  @belongsTo(() => Ticket, { foreignKey: 'ticketId' })
+  declare ticket: BelongsTo<typeof Ticket>
+}

--- a/src/services/ticket_subject_service.ts
+++ b/src/services/ticket_subject_service.ts
@@ -1,0 +1,77 @@
+import type { TicketSubject, SerializedTicketSubject } from '../contracts/ticket_subject.js'
+import type TicketSubjectLink from '../models/ticket_subject_link.js'
+import type Ticket from '../models/ticket.js'
+import { getConfig } from '../helpers/config.js'
+
+export class TicketSubjectNotAllowedError extends Error {
+  constructor(type: string) {
+    super(`Subject type [${type}] is not an allowed ticket subject.`)
+    this.name = 'TicketSubjectNotAllowedError'
+  }
+}
+
+/**
+ * Flatten `ticketSubjects.types` (string list or alias map) for allowlist checks.
+ */
+export function ticketSubjectAllowedTypes(): string[] {
+  const raw = getConfig().ticketSubjects?.types
+  if (!raw) {
+    return []
+  }
+  if (Array.isArray(raw)) {
+    return raw
+  }
+  return Object.entries(raw).flatMap(([alias, className]) => [alias, className])
+}
+
+export function assertTicketSubjectTypeAllowed(subjectType: string): void {
+  const allowed = ticketSubjectAllowedTypes()
+  if (allowed.length > 0 && !allowed.includes(subjectType)) {
+    throw new TicketSubjectNotAllowedError(subjectType)
+  }
+}
+
+export function isTicketSubjectPresentable(value: unknown): value is TicketSubject {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as TicketSubject).ticketSubjectTitle === 'function'
+  )
+}
+
+export default class TicketSubjectService {
+  get resolver(): ((type: string, id: string) => Promise<TicketSubject | null>) | undefined {
+    return getConfig().ticketSubjects?.resolver
+  }
+
+  async serializeLinks(links: TicketSubjectLink[]): Promise<SerializedTicketSubject[]> {
+    const resolver = this.resolver
+    const result: SerializedTicketSubject[] = []
+
+    for (const link of links) {
+      const resolved = resolver ? await resolver(link.subjectType, link.subjectId) : null
+      const presents = isTicketSubjectPresentable(resolved)
+
+      result.push({
+        type: link.subjectType,
+        id: link.subjectId,
+        role: link.role,
+        title: presents ? resolved.ticketSubjectTitle() : `${link.subjectType}#${link.subjectId}`,
+        subtitle: presents ? resolved.ticketSubjectSubtitle() : null,
+        url: presents ? resolved.ticketSubjectUrl() : null,
+        color: presents ? resolved.ticketSubjectColor() : null,
+        icon: presents ? resolved.ticketSubjectIcon() : null,
+        missing: !presents,
+      })
+    }
+
+    return result
+  }
+
+  async serializeForTicket(ticket: Ticket): Promise<SerializedTicketSubject[]> {
+    await ticket.load('subjects', (query) => {
+      query.orderBy('position', 'asc')
+    })
+    return this.serializeLinks(ticket.subjects)
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@
 
 import { t } from './support/i18n.js'
 import type { TicketAction, TicketActionConfig } from './contracts/ticket_action.js'
+import type { TicketSubject } from './contracts/ticket_subject.js'
 
 /**
  * Ticket statuses
@@ -273,6 +274,16 @@ export interface EscalatedConfig {
 
   activityLog: {
     retentionDays: number
+  }
+
+  /**
+   * Host entities a ticket can be *about* (Project, Customer, asset, …).
+   * `types` allowlists morph types for the agent/admin attach API.
+   * `resolver` maps type/id to presentation data for serialization.
+   */
+  ticketSubjects?: {
+    types?: string[] | Record<string, string>
+    resolver?: (type: string, id: string) => Promise<TicketSubject | null>
   }
 
   inboundEmail: {

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -43,6 +43,7 @@ const AdminAutomationsController = () =>
   import('../src/controllers/admin_automations_controller.js')
 const AdminUsersController = () => import('../src/controllers/admin_users_controller.js')
 const AdminSkillController = () => import('../src/controllers/admin_skill_controller.js')
+const TicketSubjectsController = () => import('../src/controllers/ticket_subjects_controller.js')
 
 // Lazy-load controllers (core — non-UI)
 const InboundEmailController = () => import('../src/controllers/inbound_email_controller.js')
@@ -237,6 +238,12 @@ function registerUiRoutes(config: any) {
             .post('/tickets/:ticket/tags', [AgentTicketsController, 'tags'])
             .as('escalated.agent.tickets.tags')
           router
+            .post('/tickets/:ticket/subjects', [TicketSubjectsController, 'store'])
+            .as('escalated.agent.tickets.subjects.store')
+          router
+            .delete('/tickets/:ticket/subjects/:subject', [TicketSubjectsController, 'destroy'])
+            .as('escalated.agent.tickets.subjects.destroy')
+          router
             .post('/tickets/:ticket/department', [AgentTicketsController, 'department'])
             .as('escalated.agent.tickets.department')
           router
@@ -362,6 +369,12 @@ function registerUiRoutes(config: any) {
           router
             .post('/tickets/:ticket/tags', [AdminTicketsController, 'tags'])
             .as('escalated.admin.tickets.tags')
+          router
+            .post('/tickets/:ticket/subjects', [TicketSubjectsController, 'store'])
+            .as('escalated.admin.tickets.subjects.store')
+          router
+            .delete('/tickets/:ticket/subjects/:subject', [TicketSubjectsController, 'destroy'])
+            .as('escalated.admin.tickets.subjects.destroy')
           router
             .post('/tickets/:ticket/department', [AdminTicketsController, 'department'])
             .as('escalated.admin.tickets.department')

--- a/stubs/config/escalated.stub
+++ b/stubs/config/escalated.stub
@@ -200,6 +200,24 @@ const escalatedConfig: EscalatedConfig = {
   | Inbound Email
   |--------------------------------------------------------------------------
   */
+  /*
+  |--------------------------------------------------------------------------
+  | Ticket subjects
+  |--------------------------------------------------------------------------
+  |
+  | Host-app models a ticket can be *about* (Project, Customer, asset, …),
+  | distinct from the requester. List allowed morph types for the attach API
+  | and provide a resolver for UI serialization.
+  |
+  */
+  ticketSubjects: {
+    types: [
+      // 'Project',
+      // 'Customer',
+    ],
+    // resolver: async (type, id) => { ... return presentation or null },
+  },
+
   inboundEmail: {
     enabled: false,
     adapter: 'mailgun',

--- a/tests/ticket_subject_service.test.js
+++ b/tests/ticket_subject_service.test.js
@@ -1,0 +1,194 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+const SUBJECT_TYPE = 'FakeProject'
+
+function getConfig() {
+  return globalThis.__escalated_config ?? {}
+}
+
+function ticketSubjectAllowedTypes() {
+  const raw = getConfig().ticketSubjects?.types
+  if (!raw) {
+    return []
+  }
+  if (Array.isArray(raw)) {
+    return raw
+  }
+  return Object.entries(raw).flatMap(([alias, className]) => [alias, className])
+}
+
+class TicketSubjectNotAllowedError extends Error {
+  constructor(type) {
+    super(`Subject type [${type}] is not an allowed ticket subject.`)
+    this.name = 'TicketSubjectNotAllowedError'
+  }
+}
+
+function assertTicketSubjectTypeAllowed(subjectType) {
+  const allowed = ticketSubjectAllowedTypes()
+  if (allowed.length > 0 && !allowed.includes(subjectType)) {
+    throw new TicketSubjectNotAllowedError(subjectType)
+  }
+}
+
+function isTicketSubjectPresentable(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof value.ticketSubjectTitle === 'function'
+  )
+}
+
+async function serializeLinks(links, resolver) {
+  const result = []
+
+  for (const link of links) {
+    const resolved = resolver ? await resolver(link.subjectType, link.subjectId) : null
+    const presents = isTicketSubjectPresentable(resolved)
+
+    result.push({
+      type: link.subjectType,
+      id: link.subjectId,
+      role: link.role,
+      title: presents ? resolved.ticketSubjectTitle() : `${link.subjectType}#${link.subjectId}`,
+      subtitle: presents ? resolved.ticketSubjectSubtitle() : null,
+      url: presents ? resolved.ticketSubjectUrl() : null,
+      color: presents ? resolved.ticketSubjectColor() : null,
+      icon: presents ? resolved.ticketSubjectIcon() : null,
+      missing: !presents,
+    })
+  }
+
+  return result
+}
+
+class FakePresentable {
+  constructor(title, id) {
+    this.title = title
+    this.id = id
+  }
+
+  ticketSubjectTitle() {
+    return this.title
+  }
+
+  ticketSubjectSubtitle() {
+    return 'Project · Acme'
+  }
+
+  ticketSubjectUrl() {
+    return `https://app.test/projects/${this.id}`
+  }
+
+  ticketSubjectColor() {
+    return '#2563eb'
+  }
+
+  ticketSubjectIcon() {
+    return 'folder'
+  }
+}
+
+describe('ticket_subject_service', () => {
+  let savedConfig
+
+  beforeEach(() => {
+    savedConfig = globalThis.__escalated_config
+  })
+
+  afterEach(() => {
+    globalThis.__escalated_config = savedConfig
+  })
+
+  describe('ticketSubjectAllowedTypes', () => {
+    it('returns an empty list when types are unset', () => {
+      globalThis.__escalated_config = { ticketSubjects: {} }
+      assert.deepEqual(ticketSubjectAllowedTypes(), [])
+    })
+
+    it('flattens alias maps for allowlist checks', () => {
+      globalThis.__escalated_config = {
+        ticketSubjects: {
+          types: {
+            project: 'App/Models/Project',
+            customer: 'App/Models/Customer',
+          },
+        },
+      }
+      assert.deepEqual(ticketSubjectAllowedTypes(), [
+        'project',
+        'App/Models/Project',
+        'customer',
+        'App/Models/Customer',
+      ])
+    })
+  })
+
+  describe('assertTicketSubjectTypeAllowed', () => {
+    it('rejects types outside the configured allowlist', () => {
+      globalThis.__escalated_config = { ticketSubjects: { types: ['OtherType'] } }
+      assert.throws(
+        () => assertTicketSubjectTypeAllowed(SUBJECT_TYPE),
+        TicketSubjectNotAllowedError
+      )
+    })
+
+    it('allows any type when the allowlist is empty', () => {
+      globalThis.__escalated_config = { ticketSubjects: { types: [] } }
+      assert.doesNotThrow(() => assertTicketSubjectTypeAllowed(SUBJECT_TYPE))
+    })
+  })
+
+  describe('serializeLinks', () => {
+    it('serializes subjects through a resolver', async () => {
+      const resolver = async (_type, id) => new FakePresentable('Acme Redesign', id)
+      const serialized = await serializeLinks(
+        [{ subjectType: SUBJECT_TYPE, subjectId: '7', role: 'project' }],
+        resolver
+      )
+
+      assert.equal(serialized.length, 1)
+      assert.deepEqual(serialized[0], {
+        type: SUBJECT_TYPE,
+        id: '7',
+        role: 'project',
+        title: 'Acme Redesign',
+        subtitle: 'Project · Acme',
+        url: 'https://app.test/projects/7',
+        color: '#2563eb',
+        icon: 'folder',
+        missing: false,
+      })
+    })
+
+    it('falls back when the resolver returns null', async () => {
+      const serialized = await serializeLinks(
+        [{ subjectType: SUBJECT_TYPE, subjectId: '99', role: null }],
+        async () => null
+      )
+
+      assert.deepEqual(serialized[0], {
+        type: SUBJECT_TYPE,
+        id: '99',
+        role: null,
+        title: `${SUBJECT_TYPE}#99`,
+        subtitle: null,
+        url: null,
+        color: null,
+        icon: null,
+        missing: true,
+      })
+    })
+
+    it('falls back when no resolver is configured', async () => {
+      const serialized = await serializeLinks(
+        [{ subjectType: SUBJECT_TYPE, subjectId: '1', role: null }],
+        undefined
+      )
+
+      assert.equal(serialized[0]?.title, `${SUBJECT_TYPE}#1`)
+      assert.equal(serialized[0]?.missing, true)
+    })
+  })
+})

--- a/tests/ticket_subject_service.test.js
+++ b/tests/ticket_subject_service.test.js
@@ -34,9 +34,7 @@ function assertTicketSubjectTypeAllowed(subjectType) {
 
 function isTicketSubjectPresentable(value) {
   return (
-    value !== null &&
-    typeof value === 'object' &&
-    typeof value.ticketSubjectTitle === 'function'
+    value !== null && typeof value === 'object' && typeof value.ticketSubjectTitle === 'function'
   )
 }
 


### PR DESCRIPTION
AdonisJS port of Ticket Subjects (mirrors escalated-laravel#122 / escalated-nestjs#59; discussion #89). Host entities a ticket is *about* (Project/Customer/asset) — multiple, polymorphic, distinct from the requester.

- Migration `0051_create_escalated_ticket_subjects` — `ticket_id` FK cascade, `subject_type`, **string `subject_id`** (uuid/string-safe), `role`, `position`; unique `(ticket_id, subject_type, subject_id)` + `(subject_type, subject_id)` index.
- `TicketSubject` contract interface + `TicketSubjectLink` model; `Ticket` `subjects` + `attachSubject`/`detachSubject`/`syncSubjects` (idempotent, allowlist-guarded).
- Module option `ticketSubjects: { types?, resolver? }` — Lucid has no native polymorphic, so the host supplies an optional `resolver(type, id)` to map a stored link to its presentable instance (fallback `title = type#id`).
- `subjects[]` `{type,id,role,title,subtitle,url,color,icon,missing}` on agent/admin/API ticket JSON.
- Agent + admin `POST`/`DELETE` attach/detach; type resolved only via the allowlist.

`npm run build` ✅, `npm test` ✅ **493**, `npm run lint` ✅, `npm run format:check` ✅.