### PR TITLE
fix(realtime): include resolved author in reply.created broadcast

### DIFF
--- a/src/services/broadcast_service.ts
+++ b/src/services/broadcast_service.ts
@@ -240,18 +240,34 @@ export default class BroadcastService {
   /**
    * Broadcast a reply created event.
    */
-  async broadcastReplyCreated(reply: Reply, ticket: Ticket): Promise<void> {
+  async broadcastReplyCreated(reply: Reply, ticket: Ticket, author?: any): Promise<void> {
     if (reply.isInternalNote) {
       if (!this.isEventEnabled('internalNoteAdded')) return
     } else {
       if (!this.isEventEnabled('replyCreated')) return
     }
 
+    // The polymorphic author is resolved by the host app (see the Reply model
+    // note). Prefer an explicitly passed author, falling back to one the host
+    // preloaded onto the reply. Without a resolved name the payload carries
+    // only author_type/author_id and a real-time consumer renders "Unknown"
+    // until it refetches the reply. Mirrors the api_ticket_controller shape:
+    // name = user.name ?? user.fullName.
+    const resolvedAuthor = author ?? (reply as any).author ?? null
+    const authorName = resolvedAuthor
+      ? (resolvedAuthor.name ?? resolvedAuthor.fullName ?? null)
+      : null
+    const hasAuthor = reply.authorId !== null && reply.authorId !== undefined
+
     const data = {
       ticket_id: ticket.id,
       reply_id: reply.id,
       author_type: reply.authorType,
       author_id: reply.authorId,
+      author_name: authorName,
+      // Nested shape mirrors escalated-laravel / escalated-nestjs so a consumer
+      // can render reply.author.name without a server round-trip.
+      author: hasAuthor ? { id: reply.authorId, type: reply.authorType, name: authorName } : null,
       is_internal_note: reply.isInternalNote,
       body_preview: reply.body.slice(0, 100),
     }

--- a/tests/broadcasting.test.js
+++ b/tests/broadcasting.test.js
@@ -104,16 +104,24 @@ function createBroadcastService(configOverrides = {}, transport = null) {
       await this.broadcast(this.ticketChannel(ticket.id), 'ticket.assigned', data)
       await this.broadcast(this.userChannel(agentId), 'ticket.assigned', data)
     },
-    async broadcastReplyCreated(reply, ticket) {
+    async broadcastReplyCreated(reply, ticket, author) {
       if (reply.isInternalNote) {
         if (!this.isEventEnabled('internalNoteAdded')) return
       } else {
         if (!this.isEventEnabled('replyCreated')) return
       }
+      const resolvedAuthor = author ?? reply.author ?? null
+      const authorName = resolvedAuthor
+        ? (resolvedAuthor.name ?? resolvedAuthor.fullName ?? null)
+        : null
+      const hasAuthor = reply.authorId !== null && reply.authorId !== undefined
       const data = {
         ticket_id: ticket.id,
         reply_id: reply.id,
         author_type: reply.authorType,
+        author_id: reply.authorId,
+        author_name: authorName,
+        author: hasAuthor ? { id: reply.authorId, type: reply.authorType, name: authorName } : null,
         is_internal_note: reply.isInternalNote,
         body_preview: reply.body.slice(0, 100),
       }
@@ -354,6 +362,40 @@ describe('Broadcasting', () => {
       await svc.broadcastReplyCreated(reply, ticket)
 
       assert.equal(svc.dispatched[0].data.body_preview.length, 100)
+    })
+
+    it('includes a nested author when one is passed', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket({ id: 1 })
+      const reply = buildMockReply({ authorType: 'User', authorId: 5 })
+      await svc.broadcastReplyCreated(reply, ticket, { id: 5, name: 'Dana Agent' })
+
+      const data = svc.dispatched[0].data
+      assert.deepEqual(data.author, { id: 5, type: 'User', name: 'Dana Agent' })
+      assert.equal(data.author_name, 'Dana Agent')
+    })
+
+    it('falls back to an author preloaded onto the reply', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket({ id: 1 })
+      const reply = buildMockReply({
+        authorType: 'User',
+        authorId: 7,
+        author: { fullName: 'Sam Smith' },
+      })
+      await svc.broadcastReplyCreated(reply, ticket)
+
+      assert.equal(svc.dispatched[0].data.author.name, 'Sam Smith')
+    })
+
+    it('emits a null author for an unauthored (system) reply', async () => {
+      const svc = createBroadcastService({ enabled: true })
+      const ticket = buildMockTicket({ id: 1 })
+      const reply = buildMockReply({ authorType: null, authorId: null })
+      await svc.broadcastReplyCreated(reply, ticket)
+
+      assert.equal(svc.dispatched[0].data.author, null)
+      assert.equal(svc.dispatched[0].data.author_name, null)
     })
   })
 


### PR DESCRIPTION
Part of the cross-backend reply-author broadcast fan-out (tracking issue escalated-dev/escalated-laravel#125; reference fix escalated-laravel#124, NestJS escalated-nestjs#60).

## Problem

`BroadcastService.broadcastReplyCreated` emitted only `author_type` / `author_id` — no display name. A real-time consumer of `reply.created` therefore had nothing to render and showed a just-posted reply as **Unknown** until it refetched the reply. The default web UI hides this because the shared frontend `onReplyCreated` issues a `router.reload`; mobile/third-party/direct socket consumers see the raw payload.

## Fix

The polymorphic author is resolved by the host app (the `Reply` model intentionally has no Lucid `author` relation). `broadcastReplyCreated` now:

- accepts an **optional** `author` argument (falling back to an author the host preloaded onto the reply),
- resolves the name via `name ?? fullName` — the same convention as `api_ticket_controller`,
- emits a nested `author { id, type, name }` plus a flat `author_name`,
- emits `author: null` / `author_name: null` for system replies (null `author_id`).

The new parameter is optional, so existing two-arg callers keep working unchanged.

## Tests

`tests/broadcasting.test.js` (which mirrors the service logic inline) gains four cases: nested author when passed, fallback to a preloaded author, null author for system replies, and the existing preview/enablement cases stay green.

`node --test tests/broadcasting.test.js` → **32/32 passing**. Prettier + ESLint clean.

Shape matches the nested `author { id, name }` now emitted by the Laravel and NestJS ports.