### PR TITLE
fix(newsletter): UUID-safe user-id columns in newsletter migrations

### DIFF
--- a/database/migrations/0050_create_escalated_newsletter_lists.ts
+++ b/database/migrations/0050_create_escalated_newsletter_lists.ts
@@ -1,4 +1,5 @@
 import { BaseSchema } from '@adonisjs/lucid/schema'
+import { userIdColumn } from '../../src/helpers/user_id_column.js'
 
 export default class CreateEscalatedNewsletterLists extends BaseSchema {
   protected tableName = 'escalated_newsletter_lists'
@@ -10,7 +11,7 @@ export default class CreateEscalatedNewsletterLists extends BaseSchema {
       table.text('description').nullable()
       table.string('kind', 16).notNullable()
       table.json('filter_json').nullable()
-      table.integer('created_by').unsigned().nullable()
+      userIdColumn(table, 'created_by').nullable()
       table.timestamp('created_at', { useTz: true }).notNullable()
       table.timestamp('updated_at', { useTz: true }).notNullable()
 

--- a/database/migrations/0051_create_escalated_newsletter_list_members.ts
+++ b/database/migrations/0051_create_escalated_newsletter_list_members.ts
@@ -1,4 +1,5 @@
 import { BaseSchema } from '@adonisjs/lucid/schema'
+import { userIdColumn } from '../../src/helpers/user_id_column.js'
 
 export default class CreateEscalatedNewsletterListMembers extends BaseSchema {
   protected tableName = 'escalated_newsletter_list_members'
@@ -9,7 +10,7 @@ export default class CreateEscalatedNewsletterListMembers extends BaseSchema {
       table.integer('list_id').unsigned().notNullable()
       table.integer('contact_id').unsigned().notNullable()
       table.timestamp('added_at', { useTz: true }).notNullable().defaultTo(this.now())
-      table.integer('added_by').unsigned().nullable()
+      userIdColumn(table, 'added_by').nullable()
 
       table.unique(['list_id', 'contact_id'])
       table.index('contact_id')

--- a/database/migrations/0052_create_escalated_newsletter_templates.ts
+++ b/database/migrations/0052_create_escalated_newsletter_templates.ts
@@ -1,4 +1,5 @@
 import { BaseSchema } from '@adonisjs/lucid/schema'
+import { userIdColumn } from '../../src/helpers/user_id_column.js'
 
 export default class CreateEscalatedNewsletterTemplates extends BaseSchema {
   protected tableName = 'escalated_newsletter_templates'
@@ -11,7 +12,7 @@ export default class CreateEscalatedNewsletterTemplates extends BaseSchema {
       table.string('subject_template', 998).nullable()
       table.text('body_markdown').notNullable()
       table.json('merge_fields_schema').nullable()
-      table.integer('created_by').unsigned().nullable()
+      userIdColumn(table, 'created_by').nullable()
       table.timestamp('created_at', { useTz: true }).notNullable()
       table.timestamp('updated_at', { useTz: true }).notNullable()
 

--- a/database/migrations/0053_create_escalated_newsletters.ts
+++ b/database/migrations/0053_create_escalated_newsletters.ts
@@ -1,4 +1,5 @@
 import { BaseSchema } from '@adonisjs/lucid/schema'
+import { userIdColumn } from '../../src/helpers/user_id_column.js'
 
 export default class CreateEscalatedNewsletters extends BaseSchema {
   protected tableName = 'escalated_newsletters'
@@ -17,8 +18,8 @@ export default class CreateEscalatedNewsletters extends BaseSchema {
       table.string('status', 16).notNullable().defaultTo('draft')
       table.timestamp('scheduled_at', { useTz: true }).nullable()
       table.timestamp('sent_at', { useTz: true }).nullable()
-      table.integer('created_by').unsigned().nullable()
-      table.integer('sent_by').unsigned().nullable()
+      userIdColumn(table, 'created_by').nullable()
+      userIdColumn(table, 'sent_by').nullable()
       table.integer('summary_total').notNullable().defaultTo(0)
       table.integer('summary_sent').notNullable().defaultTo(0)
       table.integer('summary_opened').notNullable().defaultTo(0)


### PR DESCRIPTION
Newsletter `created_by`/`added_by`/`sent_by` used `table.integer().unsigned()`, reintroducing the integer-only host-user-key assumption. Switches them to the `userIdColumn(table, col)` helper (same as `tickets.requester_id` / `assigned_to`), so uuid/string-keyed hosts work; FK columns stay integer. tsc + prettier clean.